### PR TITLE
feat: add valuation_date + market_ytm for historical marks repricing

### DIFF
--- a/pricing/instruments/tes_bond.py
+++ b/pricing/instruments/tes_bond.py
@@ -80,6 +80,7 @@ class TesBondPricer:
         coupon_rate: float,
         market_clean_price: float = None,
         face_value: float = 100.0,
+        market_ytm: float = None,
     ) -> dict:
         """
         Compute full analytics for a TES bond.
@@ -88,25 +89,44 @@ class TesBondPricer:
             issue_date: Bond issuance date
             maturity_date: Bond maturity date
             coupon_rate: Annual coupon rate as decimal
-            market_clean_price: If provided, used to compute YTM.
+            market_clean_price: If provided, used to compute YTM from price.
             face_value: Face value
+            market_ytm: If provided, use directly as the YTM (decimal, e.g. 0.0925).
+                        Takes precedence over market_clean_price for risk metrics.
+                        Enables historical pricing with EOD marks without needing
+                        the TES curve to be built.
 
         Returns:
             dict with all analytics
         """
         bond = self.create_bond(issue_date, maturity_date, coupon_rate, face_value)
 
-        clean_price = bond.cleanPrice()
-        dirty_price = bond.dirtyPrice()
         accrued = bond.accruedAmount()
-        npv = bond.NPV()
 
-        if market_clean_price is not None:
+        if market_ytm is not None:
+            # Use the provided YTM directly — decouples pricer from TES curve.
+            # This is the historical marks path: the caller supplies the EOD YTM
+            # (e.g. from xerenity.get_tes_yield_curve_for_date).
+            ytm = market_ytm
+            clean_price = ql.BondFunctions.cleanPrice(
+                bond,
+                ql.InterestRate(ytm, ql.Actual36525(), ql.Compounded, ql.Annual),
+            )
+            dirty_price = clean_price + accrued
+            npv = dirty_price * face_value / 100.0
+            price_for_risk = clean_price
+        elif market_clean_price is not None:
+            clean_price = bond.cleanPrice()
+            dirty_price = bond.dirtyPrice()
+            npv = bond.NPV()
             ytm = bond.bondYield(
                 market_clean_price, ql.Actual36525(), ql.Compounded, ql.Annual
             )
             price_for_risk = market_clean_price
         else:
+            clean_price = bond.cleanPrice()
+            dirty_price = bond.dirtyPrice()
+            npv = bond.NPV()
             ytm = bond.bondYield(
                 clean_price, ql.Actual36525(), ql.Compounded, ql.Annual
             )

--- a/server/pricing_api/routes.py
+++ b/server/pricing_api/routes.py
@@ -23,6 +23,7 @@ from server.pricing_api.schemas import (
     IbrSwapRequest,
     TesBondRequest,
     XccySwapRequest,
+    RepricePortfolioRequest,
 )
 
 router = APIRouter(prefix="/pricing", tags=["pricing"])
@@ -201,20 +202,51 @@ def ibr_par_curve():
 
 @router.post("/tes-bond")
 def price_tes_bond(req: TesBondRequest):
-    """Price a TES bond with full analytics."""
-    _ensure_curves_built()
-    cm = _get_cm()
-    if cm.tes_curve is None:
-        raise HTTPException(400, "TES curve not built. Provide bond data via /curves/build.")
+    """Price a TES bond with full analytics.
 
-    tes = TesBondPricer(cm)
-    result = tes.analytics(
-        issue_date=_parse_date(req.issue_date),
-        maturity_date=_parse_date(req.maturity_date),
-        coupon_rate=req.coupon_rate,
-        market_clean_price=req.market_clean_price,
-        face_value=req.face_value,
-    )
+    Supports two historical-repricing modes (backward compatible — all new params
+    are optional and default to existing behavior):
+
+    1. market_ytm: When provided, uses this YTM directly instead of fetching from
+       the TES curve. The TES curve does NOT need to be built. Ideal for historical
+       marks pricing where the frontend supplies the EOD YTM per bond.
+
+    2. valuation_date: When provided, shifts the QuantLib evaluation date so that
+       accrual, duration, and convexity are computed as of that historical date.
+       Falls back to today when None.
+    """
+    cm = _get_cm()
+
+    # When market_ytm is supplied, we bypass the TES curve entirely.
+    # The bond is still priced relative to its own fixed cash-flows; the caller
+    # provides the market yield (e.g. from xerenity.get_tes_yield_curve_for_date).
+    if req.market_ytm is None:
+        # Standard path: need the TES curve to derive price/yield.
+        _ensure_curves_built()
+        if cm.tes_curve is None:
+            raise HTTPException(400, "TES curve not built. Provide bond data via /curves/build.")
+
+    # Override valuation date when pricing a historical mark.
+    original_eval_date = None
+    if req.valuation_date is not None:
+        original_eval_date = ql.Settings.instance().evaluationDate
+        hist_date = _parse_date(req.valuation_date)
+        cm.set_valuation_date(hist_date)
+
+    try:
+        tes = TesBondPricer(cm)
+        result = tes.analytics(
+            issue_date=_parse_date(req.issue_date),
+            maturity_date=_parse_date(req.maturity_date),
+            coupon_rate=req.coupon_rate,
+            market_clean_price=req.market_clean_price,
+            face_value=req.face_value,
+            market_ytm=req.market_ytm,
+        )
+    finally:
+        # Restore the global evaluation date so we don't affect other requests.
+        if original_eval_date is not None:
+            cm.set_valuation_date(original_eval_date)
 
     if "maturity" in result and hasattr(result["maturity"], "isoformat"):
         result["maturity"] = result["maturity"].isoformat()
@@ -248,3 +280,182 @@ def price_xccy_swap(req: XccySwapRequest):
             result[key] = result[key].isoformat()
 
     return result
+
+
+# ── Portfolio Repricing Endpoint ──
+
+
+def _serialize_portfolio_result(result: dict) -> dict:
+    """Convert datetime/date objects to ISO strings for JSON serialization."""
+    out = {}
+    for k, v in result.items():
+        if hasattr(v, "isoformat"):
+            out[k] = v.isoformat()
+        elif isinstance(v, float):
+            out[k] = round(v, 6) if abs(v) < 1e12 else round(v, 2)
+        else:
+            out[k] = v
+    return out
+
+
+@router.post("/reprice-portfolio")
+def reprice_portfolio(req: RepricePortfolioRequest):
+    """Reprice a portfolio of derivatives (XCCY swaps, NDFs, IBR swaps).
+
+    Supports optional historical repricing via valuation_date (backward compatible):
+
+    - When valuation_date is None: uses currently loaded curves (existing behavior).
+    - When valuation_date is provided: rebuilds all curves from EOD market data for
+      that date (IBR, SOFR, FX spot) before pricing, then restores the original state.
+
+    All position lists default to empty, so callers can send only the instrument
+    types they hold.
+
+    Returns:
+        dict with per-instrument results and portfolio summary NPV.
+    """
+    cm = _get_cm()
+    loader = _get_loader()
+
+    # ── Historical repricing: rebuild curves for the requested date ──
+    original_eval_date = None
+    original_ibr_market = None
+    original_sofr_market = None
+    original_fx_spot = None
+    curves_rebuilt_for_history = False
+
+    if req.valuation_date is not None:
+        # Save current state so we can restore after pricing.
+        original_eval_date = ql.Settings.instance().evaluationDate
+        original_ibr_market = dict(cm._ibr_market)
+        original_sofr_market = dict(cm._sofr_market)
+        original_fx_spot = cm.fx_spot
+
+        # Set valuation date.
+        hist_date = _parse_date(req.valuation_date)
+        cm.set_valuation_date(hist_date)
+
+        # Fetch historical market data for the requested date and rebuild curves.
+        ibr_data = loader.fetch_ibr_quotes(target_date=req.valuation_date)
+        if ibr_data:
+            cm.build_ibr_curve(ibr_data)
+
+        sofr_data = loader.fetch_sofr_curve(target_date=req.valuation_date)
+        if not sofr_data.empty:
+            cm.build_sofr_curve(sofr_data)
+
+        fx = loader.fetch_usdcop_spot(target_date=req.valuation_date)
+        if fx:
+            cm.set_fx_spot(fx)
+
+        curves_rebuilt_for_history = True
+
+    try:
+        _ensure_curves_built()
+
+        xccy_pricer = XccySwapPricer(cm)
+        ndf_pricer = NdfPricer(cm)
+        ibr_pricer = IbrSwapPricer(cm)
+
+        xccy_results = []
+        ndf_results = []
+        ibr_results = []
+
+        total_npv_cop = 0.0
+
+        # Price XCCY swaps
+        for pos in req.xccy_positions:
+            result = xccy_pricer.price(
+                notional_usd=pos.notional_usd,
+                start_date=_parse_date(pos.start_date),
+                maturity_date=_parse_date(pos.maturity_date),
+                xccy_basis_bps=pos.xccy_basis_bps,
+                pay_usd=pos.pay_usd,
+                fx_initial=pos.fx_initial,
+                cop_spread_bps=pos.cop_spread_bps,
+                usd_spread_bps=pos.usd_spread_bps,
+            )
+            serialized = _serialize_portfolio_result(result)
+            if pos.position_id is not None:
+                serialized["position_id"] = pos.position_id
+            xccy_results.append(serialized)
+            total_npv_cop += result.get("npv_cop", 0.0)
+
+        # Price NDFs
+        for pos in req.ndf_positions:
+            mat = _parse_date(pos.maturity_date)
+            if pos.use_market_forward and pos.market_forward is not None:
+                result = ndf_pricer.price_from_market_points(
+                    notional_usd=pos.notional_usd,
+                    strike=pos.strike,
+                    maturity_date=mat,
+                    market_forward=pos.market_forward,
+                    direction=pos.direction,
+                    spot=pos.spot,
+                )
+            else:
+                result = ndf_pricer.price(
+                    notional_usd=pos.notional_usd,
+                    strike=pos.strike,
+                    maturity_date=mat,
+                    direction=pos.direction,
+                    spot=pos.spot,
+                )
+            serialized = _serialize_portfolio_result(result)
+            if pos.position_id is not None:
+                serialized["position_id"] = pos.position_id
+            ndf_results.append(serialized)
+            total_npv_cop += result.get("npv_cop", 0.0)
+
+        # Price IBR swaps
+        for pos in req.ibr_swap_positions:
+            if pos.tenor_years is not None:
+                tenor = ql.Period(pos.tenor_years, ql.Years)
+                result = ibr_pricer.price(
+                    pos.notional, tenor, pos.fixed_rate, pos.pay_fixed, pos.spread
+                )
+            elif pos.maturity_date is not None:
+                mat = _parse_date(pos.maturity_date)
+                result = ibr_pricer.price(
+                    pos.notional, mat, pos.fixed_rate, pos.pay_fixed, pos.spread
+                )
+            else:
+                raise HTTPException(
+                    400,
+                    f"IBR swap position '{pos.position_id}' requires "
+                    "either tenor_years or maturity_date.",
+                )
+            serialized = _serialize_portfolio_result(result)
+            if pos.position_id is not None:
+                serialized["position_id"] = pos.position_id
+            ibr_results.append(serialized)
+            # IBR NPV is already in COP.
+            total_npv_cop += result.get("npv", 0.0)
+
+        fx_spot_used = cm.fx_spot
+        return {
+            "valuation_date": req.valuation_date,
+            "fx_spot": fx_spot_used,
+            "xccy_swaps": xccy_results,
+            "ndfs": ndf_results,
+            "ibr_swaps": ibr_results,
+            "total_npv_cop": round(total_npv_cop, 2),
+            "total_npv_usd": round(total_npv_cop / fx_spot_used, 2) if fx_spot_used else None,
+        }
+
+    finally:
+        # Restore original curves and evaluation date so the singleton is not
+        # left in the historical state for subsequent requests.
+        if curves_rebuilt_for_history:
+            cm.set_valuation_date(original_eval_date)
+            if original_ibr_market:
+                # Rebuild curves from original market data to restore the handle.
+                loader_ibr = loader.fetch_ibr_quotes()
+                if loader_ibr:
+                    cm.build_ibr_curve(loader_ibr)
+            if original_sofr_market:
+                loader_sofr = loader.fetch_sofr_curve()
+                if not loader_sofr.empty:
+                    cm.build_sofr_curve(loader_sofr)
+            if original_fx_spot is not None:
+                cm.set_fx_spot(original_fx_spot)

--- a/server/pricing_api/schemas.py
+++ b/server/pricing_api/schemas.py
@@ -1,6 +1,6 @@
 """Pydantic request/response models for pricing API."""
 from pydantic import BaseModel, Field
-from typing import Optional
+from typing import List, Optional
 
 
 class BuildCurvesRequest(BaseModel):
@@ -39,6 +39,21 @@ class TesBondRequest(BaseModel):
     coupon_rate: float = Field(..., description="Coupon rate as decimal (e.g., 0.07)")
     market_clean_price: Optional[float] = None
     face_value: float = 100.0
+    market_ytm: Optional[float] = Field(
+        None,
+        description=(
+            "Market YTM as decimal (e.g., 0.0925 for 9.25%). "
+            "When provided, bypasses the TES curve and uses this yield directly. "
+            "Enables historical pricing with EOD marks."
+        ),
+    )
+    valuation_date: Optional[str] = Field(
+        None,
+        description=(
+            "ISO date string YYYY-MM-DD. When provided, sets QuantLib evaluation "
+            "date to this date for historical repricing. Defaults to today."
+        ),
+    )
 
 
 class XccySwapRequest(BaseModel):
@@ -50,3 +65,61 @@ class XccySwapRequest(BaseModel):
     fx_initial: Optional[float] = None
     cop_spread_bps: float = 0.0
     usd_spread_bps: float = 0.0
+
+
+# ── Position schemas for reprice-portfolio ──
+
+class NdfPosition(BaseModel):
+    notional_usd: float
+    strike: float
+    maturity_date: str = Field(..., description="ISO date string YYYY-MM-DD")
+    direction: str = Field("buy", description="'buy' or 'sell'")
+    spot: Optional[float] = None
+    use_market_forward: bool = False
+    market_forward: Optional[float] = None
+    position_id: Optional[str] = Field(None, description="Optional identifier for the position")
+
+
+class IbrSwapPosition(BaseModel):
+    notional: float
+    tenor_years: Optional[int] = None
+    maturity_date: Optional[str] = None
+    fixed_rate: float = Field(..., description="Fixed rate as decimal (e.g., 0.095)")
+    pay_fixed: bool = True
+    spread: float = 0.0
+    position_id: Optional[str] = Field(None, description="Optional identifier for the position")
+
+
+class XccySwapPosition(BaseModel):
+    notional_usd: float
+    start_date: str
+    maturity_date: str
+    xccy_basis_bps: float = 0.0
+    pay_usd: bool = True
+    fx_initial: Optional[float] = None
+    cop_spread_bps: float = 0.0
+    usd_spread_bps: float = 0.0
+    position_id: Optional[str] = Field(None, description="Optional identifier for the position")
+
+
+class RepricePortfolioRequest(BaseModel):
+    xccy_positions: List[XccySwapPosition] = Field(
+        default_factory=list,
+        description="List of XCCY swap positions to reprice",
+    )
+    ndf_positions: List[NdfPosition] = Field(
+        default_factory=list,
+        description="List of NDF positions to reprice",
+    )
+    ibr_swap_positions: List[IbrSwapPosition] = Field(
+        default_factory=list,
+        description="List of IBR swap positions to reprice",
+    )
+    valuation_date: Optional[str] = Field(
+        None,
+        description=(
+            "ISO date string YYYY-MM-DD for historical repricing. "
+            "When provided, curves are rebuilt from EOD market data for that date. "
+            "When None, uses the currently built curves (today's market data)."
+        ),
+    )

--- a/server/pricing_api/views.py
+++ b/server/pricing_api/views.py
@@ -225,24 +225,52 @@ def pricing_ibr_par_curve(request):
 
 @csrf_exempt
 def pricing_tes_bond(request):
-    """Price a TES bond with full analytics."""
-    err = _ensure_curves()
-    if err:
-        return err
+    """Price a TES bond with full analytics.
 
+    Supports two historical-repricing modes (backward compatible — all new params
+    are optional and default to existing behavior):
+
+    1. market_ytm: When provided, uses this YTM directly instead of fetching from
+       the TES curve. The TES curve does NOT need to be built. Ideal for historical
+       marks pricing where the frontend supplies the EOD YTM per bond.
+
+    2. valuation_date: When provided, shifts the QuantLib evaluation date so that
+       accrual, duration, and convexity are computed as of that historical date.
+       Falls back to today when None.
+    """
     cm = _get_cm()
-    if cm.tes_curve is None:
-        return responseHttpError("TES curve not built", 400)
-
     body = json.loads(request.body)
-    tes = TesBondPricer(cm)
-    result = tes.analytics(
-        issue_date=_parse_date(body["issue_date"]),
-        maturity_date=_parse_date(body["maturity_date"]),
-        coupon_rate=body["coupon_rate"],
-        market_clean_price=body.get("market_clean_price"),
-        face_value=body.get("face_value", 100.0),
-    )
+
+    market_ytm = body.get("market_ytm")
+    valuation_date_str = body.get("valuation_date")
+
+    # When market_ytm is supplied, we bypass the TES curve entirely.
+    if market_ytm is None:
+        err = _ensure_curves()
+        if err:
+            return err
+        if cm.tes_curve is None:
+            return responseHttpError("TES curve not built", 400)
+
+    original_eval_date = None
+    if valuation_date_str is not None:
+        original_eval_date = ql.Settings.instance().evaluationDate
+        hist_date = _parse_date(valuation_date_str)
+        cm.set_valuation_date(hist_date)
+
+    try:
+        tes = TesBondPricer(cm)
+        result = tes.analytics(
+            issue_date=_parse_date(body["issue_date"]),
+            maturity_date=_parse_date(body["maturity_date"]),
+            coupon_rate=body["coupon_rate"],
+            market_clean_price=body.get("market_clean_price"),
+            face_value=body.get("face_value", 100.0),
+            market_ytm=market_ytm,
+        )
+    finally:
+        if original_eval_date is not None:
+            cm.set_valuation_date(original_eval_date)
 
     return responseHttpOk(_serialize(result))
 
@@ -272,3 +300,161 @@ def pricing_xccy_swap(request):
     )
 
     return responseHttpOk(_serialize(result))
+
+
+# ── Portfolio Repricing ──
+
+@csrf_exempt
+def pricing_reprice_portfolio(request):
+    """Reprice a portfolio of derivatives (XCCY swaps, NDFs, IBR swaps).
+
+    Supports optional historical repricing via valuation_date (backward compatible):
+
+    - When valuation_date is None: uses currently loaded curves (existing behavior).
+    - When valuation_date is provided: rebuilds all curves from EOD market data for
+      that date (IBR, SOFR, FX spot) before pricing, then restores the original state.
+
+    Request body (all position lists optional, default to []):
+        xccy_positions: list of XCCY position objects
+        ndf_positions: list of NDF position objects
+        ibr_swap_positions: list of IBR swap position objects
+        valuation_date: ISO date string YYYY-MM-DD (optional)
+    """
+    cm = _get_cm()
+    loader = _get_loader()
+    body = json.loads(request.body) if request.body else {}
+
+    valuation_date_str = body.get("valuation_date")
+
+    original_eval_date = None
+    original_ibr_market = None
+    original_sofr_market = None
+    original_fx_spot = None
+    curves_rebuilt_for_history = False
+
+    if valuation_date_str is not None:
+        original_eval_date = ql.Settings.instance().evaluationDate
+        original_ibr_market = dict(cm._ibr_market)
+        original_sofr_market = dict(cm._sofr_market)
+        original_fx_spot = cm.fx_spot
+
+        hist_date = _parse_date(valuation_date_str)
+        cm.set_valuation_date(hist_date)
+
+        ibr_data = loader.fetch_ibr_quotes(target_date=valuation_date_str)
+        if ibr_data:
+            cm.build_ibr_curve(ibr_data)
+
+        sofr_data = loader.fetch_sofr_curve(target_date=valuation_date_str)
+        if not sofr_data.empty:
+            cm.build_sofr_curve(sofr_data)
+
+        fx = loader.fetch_usdcop_spot(target_date=valuation_date_str)
+        if fx:
+            cm.set_fx_spot(fx)
+
+        curves_rebuilt_for_history = True
+
+    try:
+        err = _ensure_curves()
+        if err:
+            return err
+
+        xccy_pricer = XccySwapPricer(cm)
+        ndf_pricer = NdfPricer(cm)
+        ibr_pricer = IbrSwapPricer(cm)
+
+        xccy_results = []
+        ndf_results = []
+        ibr_results = []
+        total_npv_cop = 0.0
+
+        for pos in body.get("xccy_positions", []):
+            result = xccy_pricer.price(
+                notional_usd=pos["notional_usd"],
+                start_date=_parse_date(pos["start_date"]),
+                maturity_date=_parse_date(pos["maturity_date"]),
+                xccy_basis_bps=pos.get("xccy_basis_bps", 0.0),
+                pay_usd=pos.get("pay_usd", True),
+                fx_initial=pos.get("fx_initial"),
+                cop_spread_bps=pos.get("cop_spread_bps", 0.0),
+                usd_spread_bps=pos.get("usd_spread_bps", 0.0),
+            )
+            row = _serialize(result)
+            if pos.get("position_id"):
+                row["position_id"] = pos["position_id"]
+            xccy_results.append(row)
+            total_npv_cop += result.get("npv_cop", 0.0)
+
+        for pos in body.get("ndf_positions", []):
+            mat = _parse_date(pos["maturity_date"])
+            if pos.get("use_market_forward") and pos.get("market_forward"):
+                result = ndf_pricer.price_from_market_points(
+                    notional_usd=pos["notional_usd"],
+                    strike=pos["strike"],
+                    maturity_date=mat,
+                    market_forward=pos["market_forward"],
+                    direction=pos.get("direction", "buy"),
+                    spot=pos.get("spot"),
+                )
+            else:
+                result = ndf_pricer.price(
+                    notional_usd=pos["notional_usd"],
+                    strike=pos["strike"],
+                    maturity_date=mat,
+                    direction=pos.get("direction", "buy"),
+                    spot=pos.get("spot"),
+                )
+            row = _serialize(result)
+            if pos.get("position_id"):
+                row["position_id"] = pos["position_id"]
+            ndf_results.append(row)
+            total_npv_cop += result.get("npv_cop", 0.0)
+
+        for pos in body.get("ibr_swap_positions", []):
+            if pos.get("tenor_years"):
+                tenor = ql.Period(int(pos["tenor_years"]), ql.Years)
+                result = ibr_pricer.price(
+                    pos["notional"], tenor, pos["fixed_rate"],
+                    pos.get("pay_fixed", True), pos.get("spread", 0.0),
+                )
+            elif pos.get("maturity_date"):
+                mat = _parse_date(pos["maturity_date"])
+                result = ibr_pricer.price(
+                    pos["notional"], mat, pos["fixed_rate"],
+                    pos.get("pay_fixed", True), pos.get("spread", 0.0),
+                )
+            else:
+                return responseHttpError(
+                    f"IBR swap position '{pos.get('position_id', '?')}' requires "
+                    "either tenor_years or maturity_date.",
+                    400,
+                )
+            row = _serialize(result)
+            if pos.get("position_id"):
+                row["position_id"] = pos["position_id"]
+            ibr_results.append(row)
+            total_npv_cop += result.get("npv", 0.0)
+
+        fx_spot_used = cm.fx_spot
+        return responseHttpOk({
+            "valuation_date": valuation_date_str,
+            "fx_spot": fx_spot_used,
+            "xccy_swaps": xccy_results,
+            "ndfs": ndf_results,
+            "ibr_swaps": ibr_results,
+            "total_npv_cop": round(total_npv_cop, 2),
+            "total_npv_usd": round(total_npv_cop / fx_spot_used, 2) if fx_spot_used else None,
+        })
+
+    finally:
+        if curves_rebuilt_for_history:
+            cm.set_valuation_date(original_eval_date)
+            loader_ibr = loader.fetch_ibr_quotes()
+            if loader_ibr:
+                cm.build_ibr_curve(loader_ibr)
+            loader_sofr = loader.fetch_sofr_curve()
+            if not loader_sofr.empty:
+                cm.build_sofr_curve(loader_sofr)
+            if original_fx_spot is not None:
+                cm.set_fx_spot(original_fx_spot)

--- a/xerenity_functions/urls.py
+++ b/xerenity_functions/urls.py
@@ -28,6 +28,7 @@ from server.pricing_api.views import (
     pricing_ndf, pricing_ndf_implied_curve,
     pricing_ibr_swap, pricing_ibr_par_curve,
     pricing_tes_bond, pricing_xccy_swap,
+    pricing_reprice_portfolio,
 )
 
 
@@ -160,4 +161,5 @@ urlpatterns = [
     path("pricing/ibr/par-curve", pricing_ibr_par_curve, name="pricing_ibr_par_curve"),
     path("pricing/tes-bond", pricing_tes_bond, name="pricing_tes_bond"),
     path("pricing/xccy-swap", pricing_xccy_swap, name="pricing_xccy_swap"),
+    path("pricing/reprice-portfolio", pricing_reprice_portfolio, name="pricing_reprice_portfolio"),
 ]


### PR DESCRIPTION
## Summary

- **New endpoint `POST /pricing/reprice-portfolio`**: prices a mixed portfolio of XCCY swaps, NDFs, and IBR swaps in a single call; supports optional `valuation_date` to rebuild curves from EOD market data for a historical date, then restores the current state after pricing
- **Enhanced `POST /pricing/tes-bond`**: adds optional `market_ytm` (decimal YTM used directly, bypassing TES curve — ideal for historical marks from `xerenity.get_tes_yield_curve_for_date`) and optional `valuation_date` (shifts QuantLib eval date for accurate historical accrual/duration/convexity)
- **Backward compatible**: all new parameters are optional and default to existing behavior

## Changes

| File | What changed |
|------|-------------|
| `server/pricing_api/schemas.py` | Added `market_ytm`, `valuation_date` to `TesBondRequest`; new `NdfPosition`, `IbrSwapPosition`, `XccySwapPosition`, `RepricePortfolioRequest` models |
| `server/pricing_api/routes.py` | New `/reprice-portfolio` endpoint; updated `/tes-bond` to handle `market_ytm` + `valuation_date` |
| `server/pricing_api/views.py` | Same changes for Django WSGI layer; new `pricing_reprice_portfolio` view |
| `pricing/instruments/tes_bond.py` | `analytics()` accepts `market_ytm`; derives clean price via `ql.BondFunctions.cleanPrice` when set, no TES curve required |
| `xerenity_functions/urls.py` | Registered `pricing/reprice-portfolio` URL |

## How historical repricing works

```
POST /pricing/reprice-portfolio
{
  "valuation_date": "2026-02-14",
  "xccy_positions": [...],
  "ndf_positions": [...],
  "ibr_swap_positions": [...]
}
```

When `valuation_date` is provided, the server:
1. Saves the current curve state
2. Fetches IBR, SOFR, and FX spot for that date from Supabase
3. Rebuilds curves with historical data + sets QuantLib eval date
4. Prices all positions
5. Restores the original curves + eval date (singleton stays clean)

```
POST /pricing/tes-bond
{
  "issue_date": "2020-01-01",
  "maturity_date": "2030-01-01",
  "coupon_rate": 0.07,
  "market_ytm": 0.0925,
  "valuation_date": "2026-02-14"
}
```

With `market_ytm`, the TES curve does **not** need to be built — the pricer is fully decoupled from real-time market data.

## Test plan

- [ ] Verify existing `/pricing/tes-bond` without new params behaves identically
- [ ] Call `/pricing/tes-bond` with `market_ytm=0.09` and confirm `ytm` in response matches input
- [ ] Call `/pricing/reprice-portfolio` with `valuation_date=null` (omitted) — should use existing curves
- [ ] Call `/pricing/reprice-portfolio` with a historical `valuation_date` — should rebuild curves and return historical NPV
- [ ] Verify `/pricing/curves/status` after a historical reprice call shows today's curves (not historical)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)