### PR TITLE
fix(xccy): handle mid-life swaps (negative time QuantLib error)

### DIFF
--- a/pricing/instruments/xccy_swap.py
+++ b/pricing/instruments/xccy_swap.py
@@ -76,8 +76,14 @@ class XccySwapPricer:
         usd_cal = self.cm.sofr_index.fixingCalendar()
         joint_cal = ql.JointCalendar(cop_cal, usd_cal)
 
+        eval_date = ql.Settings.instance().evaluationDate
+        is_midlife = start_date < eval_date
+
+        # For mid-life swaps, build schedule from evaluation_date to avoid
+        # QuantLib "negative time" errors when discounting past dates.
+        schedule_start = eval_date if is_midlife else start_date
         schedule = ql.Schedule(
-            start_date, maturity_date,
+            schedule_start, maturity_date,
             payment_frequency,
             joint_cal,
             ql.ModifiedFollowing, ql.ModifiedFollowing,
@@ -102,14 +108,20 @@ class XccySwapPricer:
         )
 
         # Notional exchange PV
-        usd_notional_pv = (
-            -notional_usd * self.cm.sofr_handle.discount(start_date)
-            + notional_usd * self.cm.sofr_handle.discount(maturity_date)
-        )
-        cop_notional_pv = (
-            notional_cop * self.cm.ibr_handle.discount(start_date)
-            - notional_cop * self.cm.ibr_handle.discount(maturity_date)
-        )
+        # Initial exchange: already settled for mid-life swaps, so PV = 0.
+        # Only the final re-exchange at maturity remains.
+        if is_midlife:
+            usd_notional_pv = notional_usd * self.cm.sofr_handle.discount(maturity_date)
+            cop_notional_pv = -notional_cop * self.cm.ibr_handle.discount(maturity_date)
+        else:
+            usd_notional_pv = (
+                -notional_usd * self.cm.sofr_handle.discount(start_date)
+                + notional_usd * self.cm.sofr_handle.discount(maturity_date)
+            )
+            cop_notional_pv = (
+                notional_cop * self.cm.ibr_handle.discount(start_date)
+                - notional_cop * self.cm.ibr_handle.discount(maturity_date)
+            )
 
         usd_total = usd_leg_value + usd_notional_pv
         cop_total = cop_leg_value + cop_notional_pv


### PR DESCRIPTION
## Problem

XCCY swaps were showing `Err` in the portfolio when pricing with `evaluation_date > start_date`. QuantLib throws:

```
RuntimeError: negative time (-0.0388889) given
```

This happens because `discount_handle.discount(start_date)` is called with a past date (e.g. start_date = Feb 16, evaluation_date = Mar 2 → -14 days).

## Root cause

The `price()` method always tried to compute the PV of the **initial notional exchange** at `start_date`, even for running swaps where that exchange already happened.

## Fix

For mid-life swaps (`start_date < evaluation_date`):
1. Build the coupon schedule from `evaluation_date` (not `start_date`) → avoids negative time in `_value_ois_leg`
2. Set initial notional exchange PV = 0 (already settled, not in current MTM)
3. Only include final notional re-exchange at maturity (always in the future)

For new swaps (`start_date >= evaluation_date`): unchanged behavior.

## Impact

All XCCY positions with past start dates now price correctly with any evaluation date.

Closes #(xccy-midlife-pricing)