### PR TITLE
feat(risk): futures roll logic, exposure calc, VaR confidence (#66)

### DIFF
--- a/db_call/db_call.py
+++ b/db_call/db_call.py
@@ -6,6 +6,7 @@ import os
 xty = Xerenity(
     username=os.getenv('XTY_USER'),
     password=os.getenv('XTY_PWD'),
+    auto_refresh=True,
 )
 
 

--- a/gestion_de_riesgos/collectors/base_collector.py
+++ b/gestion_de_riesgos/collectors/base_collector.py
@@ -17,6 +17,7 @@ Arquitectura:
 from abc import ABC, abstractmethod
 from pathlib import Path
 from datetime import datetime, date, timedelta
+import calendar
 import pandas as pd
 import numpy as np
 import json
@@ -42,24 +43,43 @@ IB_PORT = 7496   # 7497 para paper trading
 # =======================================================
 
 # Config de contratos por commodity
+#
+# Reglas de vencimiento por exchange:
+#   CBOT (ZC):  Ultimo dia de trading = dia habil anterior al 15 del mes del contrato
+#   ICE (SB):   Ultimo dia de trading = ultimo dia habil del mes ANTERIOR al contrato
+#   ICE (CC):   Ultimo dia de trading ~ 10 dias habiles antes del fin del mes del contrato
+#
+# roll_days_before: dias calendario antes del vencimiento para hacer el roll
+# expiry_day: dia aproximado de vencimiento dentro del mes de expiracion
+# expiry_month_offset: 0 = mes del contrato, -1 = mes anterior al contrato
+#
 COMMODITY_CONFIG = {
     'MAIZ': {
         'symbol': 'ZC',
         'exchanges': ['CBOT', 'ECBOT'],
         'months': {'H': '03', 'K': '05', 'N': '07', 'U': '09', 'Z': '12'},
         'code_pattern': r'ZC[HKNUZ]\d{2}',
+        'expiry_day': 14,
+        'expiry_month_offset': 0,
+        'roll_days_before': 10,
     },
     'AZUCAR': {
         'symbol': 'SB',
         'exchanges': ['NYBOT', 'ICEUS'],
         'months': {'H': '03', 'K': '05', 'N': '07', 'V': '10'},
         'code_pattern': r'SB[HKNV]\d{1,2}',
+        'expiry_day': 28,
+        'expiry_month_offset': -1,
+        'roll_days_before': 10,
     },
     'CACAO': {
         'symbol': 'CC',
         'exchanges': ['NYBOT', 'ICEUS'],
         'months': {'H': '03', 'K': '05', 'N': '07', 'U': '09', 'Z': '12'},
         'code_pattern': r'CC[HKNUZ]\d{2}',
+        'expiry_day': 14,
+        'expiry_month_offset': 0,
+        'roll_days_before': 10,
     },
 }
 
@@ -96,42 +116,95 @@ def _load_json(path: Path) -> dict:
         return json.load(f)
 
 
-def _pick_front_contract(db: dict, config: dict) -> str:
+def _get_expiry_date(yyyymm: str, config: dict) -> date:
     """
-    Selecciona el contrato front (vigente mas cercano con datos recientes).
-    Logica basada en maiz.ipynb: pick_front_contract_async.
+    Calcula la fecha aproximada de vencimiento de un contrato.
+
+    Usa expiry_day y expiry_month_offset del config:
+    - expiry_day: dia del mes en que vence (default 14)
+    - expiry_month_offset: 0 = mes del contrato, -1 = mes anterior (default 0)
+
+    Ejemplo:
+        ZCH26 (Mar 2026, CBOT): expiry_day=14, offset=0 -> 14 Mar 2026
+        SBH26 (Mar 2026, ICE):  expiry_day=28, offset=-1 -> 28 Feb 2026
+    """
+    year = int(yyyymm[:4])
+    month = int(yyyymm[4:6])
+
+    offset = config.get('expiry_month_offset', 0)
+    month += offset
+    if month <= 0:
+        month += 12
+        year -= 1
+    elif month > 12:
+        month -= 12
+        year += 1
+
+    expiry_day = config.get('expiry_day', 14)
+    max_day = calendar.monthrange(year, month)[1]
+    day = min(expiry_day, max_day)
+
+    return date(year, month, day)
+
+
+def _get_roll_date(yyyymm: str, config: dict) -> date:
+    """
+    Calcula la fecha en que se debe hacer el roll al siguiente contrato.
+    Roll date = expiry_date - roll_days_before.
+    """
+    expiry = _get_expiry_date(yyyymm, config)
+    roll_days = config.get('roll_days_before', 10)
+    return expiry - timedelta(days=roll_days)
+
+
+def _pick_front_contract(db: dict, config: dict, ref_date: date = None) -> str:
+    """
+    Selecciona el contrato front (vigente mas cercano) usando fechas de
+    vencimiento reales en lugar de solo comparar el mes calendario.
+
+    Logica:
+    1. Calcula la fecha de roll para cada contrato
+    2. Descarta contratos cuya fecha de roll ya paso (ya debio haber rolado)
+    3. Entre los activos, toma el mas cercano a vencer
+    4. Si hay empate, prefiere el que tenga datos mas recientes
+
+    Args:
+        db: dict con datos del JSON {contract_code: [bars]}
+        config: COMMODITY_CONFIG del asset
+        ref_date: fecha de referencia (default: hoy)
     """
     pattern = config['code_pattern']
-    today = date.today()
-    today_str = today.strftime("%Y-%m-%d")
+    today = ref_date or date.today()
 
     contracts = []
     for code in db.keys():
         if re.fullmatch(pattern, code):
             try:
                 yyyymm = _code_to_yyyymm(code, config)
-                contracts.append((code, yyyymm))
+                expiry = _get_expiry_date(yyyymm, config)
+                roll = _get_roll_date(yyyymm, config)
+                contracts.append((code, yyyymm, expiry, roll))
             except ValueError:
                 continue
 
     if not contracts:
         return ""
 
-    # Filtrar contratos cuyo mes de expiracion >= mes actual
-    current_yyyymm = today.strftime("%Y%m")
-    active = [(code, ym) for code, ym in contracts if ym >= current_yyyymm]
+    # Filtrar contratos cuya fecha de roll aun no ha pasado
+    active = [(code, ym, exp, roll) for code, ym, exp, roll in contracts if roll > today]
 
     if not active:
-        # Si no hay activos, tomar el mas reciente
-        active = contracts
+        # Todos ya rolaron: tomar el mas reciente (ultimo en vencer)
+        contracts.sort(key=lambda x: x[2], reverse=True)
+        return contracts[0][0]
 
-    # Ordenar por fecha de expiracion y tomar el mas cercano
-    active.sort(key=lambda x: x[1])
+    # Ordenar por fecha de expiracion (mas cercano primero)
+    active.sort(key=lambda x: x[2])
 
-    # Preferir el que tenga datos mas recientes
+    # Entre los 3 mas cercanos, preferir el que tenga datos mas recientes
     best_code = active[0][0]
     best_last_date = ""
-    for code, ym in active[:3]:  # Revisar los 3 mas cercanos
+    for code, ym, exp, roll in active[:3]:
         bars = db.get(code, [])
         if bars:
             last = max(r["date"] for r in bars)
@@ -190,6 +263,7 @@ class BaseCollector(ABC):
                 'date': str(row['date']),
                 'asset': self.asset_name,
                 'price': float(row['close']),
+                'contract': row.get('contract'),
                 'collected_at': datetime.now().isoformat(),
             }
             for _, row in prices_df.iterrows()
@@ -226,6 +300,7 @@ class FuturesJSONCollector(BaseCollector):
             return df
 
         df = df[df['date'] <= end_date]
+        df['contract'] = contract
         return df
 
     def get_available_contracts(self) -> list[str]:
@@ -244,6 +319,55 @@ class FuturesJSONCollector(BaseCollector):
         """Retorna el codigo del contrato front actual."""
         db = _load_json(self.json_path)
         return _pick_front_contract(db, self.config)
+
+    def get_contract_schedule(self) -> list[dict]:
+        """
+        Retorna el calendario de contratos con fechas de expiracion y roll.
+
+        Returns:
+            Lista de dicts con: code, yyyymm, expiry_date, roll_date, status,
+                                last_data_date, data_points
+        """
+        db = _load_json(self.json_path)
+        pattern = self.config['code_pattern']
+        today = date.today()
+        front = _pick_front_contract(db, self.config)
+
+        schedule = []
+        for code in sorted(db.keys()):
+            if not re.fullmatch(pattern, code):
+                continue
+            try:
+                yyyymm = _code_to_yyyymm(code, self.config)
+                expiry = _get_expiry_date(yyyymm, self.config)
+                roll = _get_roll_date(yyyymm, self.config)
+
+                bars = db.get(code, [])
+                last_date = max((r["date"] for r in bars), default=None) if bars else None
+
+                if code == front:
+                    status = "FRONT"
+                elif expiry < today:
+                    status = "EXPIRED"
+                elif roll <= today:
+                    status = "ROLLING"
+                else:
+                    status = "ACTIVE"
+
+                schedule.append({
+                    'code': code,
+                    'yyyymm': yyyymm,
+                    'expiry_date': expiry.isoformat(),
+                    'roll_date': roll.isoformat(),
+                    'status': status,
+                    'last_data_date': last_date,
+                    'data_points': len(bars),
+                    'is_front': code == front,
+                })
+            except ValueError:
+                continue
+
+        return schedule
 
 
 class CornCollector(FuturesJSONCollector):
@@ -334,6 +458,7 @@ class TRMCollector(BaseCollector):
         result = pd.DataFrame({
             'date': df["fecha"].dt.strftime('%Y-%m-%d'),
             'close': df["precio"].values,
+            'contract': 'TRM',
         })
 
         return result.reset_index(drop=True)
@@ -363,6 +488,7 @@ class TRMCollector(BaseCollector):
         result = pd.DataFrame({
             'date': df["fecha"].dt.strftime('%Y-%m-%d'),
             'close': df["precio"].values,
+            'contract': 'TRM',
         })
 
         return result.reset_index(drop=True)

--- a/gestion_de_riesgos/db_risk.py
+++ b/gestion_de_riesgos/db_risk.py
@@ -16,6 +16,21 @@ def _get_xty():
     return xty
 
 
+def _fetch_risk_prices_raw(initial_date: str, final_date: str) -> pd.DataFrame:
+    """Fetch raw risk_prices rows (date, asset, price, contract)."""
+    xty = _get_xty()
+    data = xty.session.table('risk_prices') \
+        .select('date,asset,price,contract') \
+        .gte('date', initial_date) \
+        .lte('date', final_date) \
+        .order('date', desc=False) \
+        .execute().data
+
+    if not data:
+        return pd.DataFrame()
+    return pd.DataFrame(data)
+
+
 def get_risk_prices(initial_date: str, final_date: str) -> pd.DataFrame:
     """
     Obtiene precios historicos de activos de riesgo.
@@ -27,18 +42,9 @@ def get_risk_prices(initial_date: str, final_date: str) -> pd.DataFrame:
     Returns:
         DataFrame con columnas: ['date', 'MAIZ', 'AZUCAR', 'CACAO', 'USD']
     """
-    xty = _get_xty()
-    data = xty.session.table('risk_prices') \
-        .select('*') \
-        .gte('date', initial_date) \
-        .lte('date', final_date) \
-        .order('date', desc=False) \
-        .execute().data
-
-    if not data:
-        return pd.DataFrame()
-
-    df = pd.DataFrame(data)
+    df = _fetch_risk_prices_raw(initial_date, final_date)
+    if df.empty:
+        return df
 
     # Pivotar: filas (date, asset, price) -> columnas ['date', 'MAIZ', 'AZUCAR', ...]
     if 'asset' in df.columns and 'price' in df.columns:
@@ -48,6 +54,26 @@ def get_risk_prices(initial_date: str, final_date: str) -> pd.DataFrame:
         return pivot
 
     return df
+
+
+def get_risk_contracts(initial_date: str, final_date: str) -> dict:
+    """
+    Retorna el ultimo contrato (ticker) usado por cada activo en el rango.
+
+    Returns:
+        dict: {'MAIZ': 'ZCH26', 'AZUCAR': 'SBK6', 'CACAO': 'CCH26', 'USD': 'TRM'}
+    """
+    df = _fetch_risk_prices_raw(initial_date, final_date)
+    if df.empty:
+        return {}
+
+    contracts = {}
+    for asset in df['asset'].unique():
+        asset_df = df[df['asset'] == asset].sort_values('date')
+        last_contract = asset_df['contract'].dropna().iloc[-1] if asset_df['contract'].notna().any() else None
+        if last_contract:
+            contracts[asset] = last_contract
+    return contracts
 
 
 def get_risk_positions(portfolio_id: str = None) -> list[dict]:
@@ -90,7 +116,7 @@ def upsert_risk_prices(records: list[dict]) -> None:
         records: Lista de dicts con: date, asset, price
     """
     xty = _get_xty()
-    xty.session.table('risk_prices').upsert(records).execute()
+    xty.session.table('risk_prices').upsert(records, on_conflict='date,asset').execute()
 
 
 def upsert_risk_positions(records: list[dict]) -> None:

--- a/gestion_de_riesgos/exposure.py
+++ b/gestion_de_riesgos/exposure.py
@@ -1,0 +1,317 @@
+"""
+Cálculo de exposición en USD por commodity.
+Basado en el instructivo de Exposición del Blotter VB.
+
+Commodities:
+  - AZUCAR (Sugar #11) - ICE SB - Centavos USD/Libra
+  - MAIZ/GLUCOSA (Corn) - CME ZC - Centavos USD/Bushel → Precio implícito glucosa
+  - COCOA EN POLVO - ICE CC - USD/Ton con factor 1.22
+  - MANTECA DE CACAO - ICE CC - USD/Ton con factor 1.95
+  - LICOR DE CACAO - ICE CC - USD/Ton con factor 1.53
+  - BOLSA ROLLO + ENVOLTURA - Precio fijo / TRM
+"""
+
+
+class CommodityExposure:
+    """Clase base para cálculo de exposición."""
+
+    def __init__(self, nombre, proyeccion_mensual):
+        self.nombre = nombre
+        self.proyeccion_mensual = proyeccion_mensual  # list 12 meses
+        self.ton_total = sum(proyeccion_mensual)
+
+    def calcular_exposicion(self):
+        raise NotImplementedError
+
+    def precio_por_ton(self):
+        if self.ton_total == 0:
+            return 0
+        return self.calcular_exposicion() / self.ton_total
+
+    def to_dict(self):
+        exposicion = self.calcular_exposicion()
+        return {
+            'nombre': self.nombre,
+            'proyeccion_mensual': self.proyeccion_mensual,
+            'ton_total': round(self.ton_total, 2),
+            'exposicion_usd': round(exposicion, 2),
+            'precio_por_ton': round(self.precio_por_ton(), 2),
+        }
+
+
+class AzucarExposure(CommodityExposure):
+    """
+    Sección 3: AZUCAR - Cálculo Contratos Futuros (ICE Sugar #11)
+    Unidad: Centavos USD / Libra
+    """
+    LIBRAS_CONTRATO = 112_000
+    LBS_PER_TON = 2204.62
+
+    def __init__(self, proyeccion_mensual, precio_cent_lb, factor_crudo_refinado=1.05):
+        super().__init__('AZUCAR', proyeccion_mensual)
+        self.precio_cent_lb = precio_cent_lb
+        self.factor_crudo_refinado = factor_crudo_refinado
+
+    def calcular_exposicion(self):
+        ton_contrato = self.LIBRAS_CONTRATO / self.LBS_PER_TON
+        ton_reales = self.ton_total * self.factor_crudo_refinado
+        num_contratos = ton_reales / ton_contrato
+        precio_x_libra = self.precio_cent_lb / 100
+        precio_x_contrato = precio_x_libra * self.LIBRAS_CONTRATO
+        return precio_x_contrato * num_contratos
+
+    def to_dict(self):
+        base = super().to_dict()
+        ton_contrato = self.LIBRAS_CONTRATO / self.LBS_PER_TON
+        ton_reales = self.ton_total * self.factor_crudo_refinado
+        num_contratos = ton_reales / ton_contrato
+        precio_x_libra = self.precio_cent_lb / 100
+        precio_x_contrato = precio_x_libra * self.LIBRAS_CONTRATO
+
+        base.update({
+            'exchange': 'ICE - SB',
+            'unidad_cotizacion': 'Centavos USD / Libra',
+            'precio_futuro': self.precio_cent_lb,
+            'ton_contrato': round(ton_contrato, 2),
+            'factor_crudo_refinado': self.factor_crudo_refinado,
+            'ton_reales': round(ton_reales, 2),
+            'num_contratos': round(num_contratos, 2),
+            'libras_x_contrato': self.LIBRAS_CONTRATO,
+            'precio_x_libra': round(precio_x_libra, 4),
+            'precio_x_contrato': round(precio_x_contrato, 2),
+        })
+        return base
+
+
+class MaizGlucosaExposure(CommodityExposure):
+    """
+    Sección 4: MAIZ / GLUCOSA - Precio Implícito (CME Corn)
+    Unidad: Centavos USD / Bushel
+    """
+    CONV_BU_TON = 0.3936825
+    CREDITO_PCT = 0.26
+
+    def __init__(self, proyeccion_mensual, precio_cent_bu, base_cent_bu,
+                 flete_usd_ton, processing_fee_usd, proc_fee_cop_kg,
+                 trm, factor_maiz_glucosa=1.495):
+        super().__init__('MAIZ', proyeccion_mensual)
+        self.precio_cent_bu = precio_cent_bu
+        self.base_cent_bu = base_cent_bu
+        self.flete_usd_ton = flete_usd_ton
+        self.processing_fee_usd = processing_fee_usd
+        self.proc_fee_cop_kg = proc_fee_cop_kg
+        self.trm = trm
+        self.factor_maiz_glucosa = factor_maiz_glucosa
+
+    def calcular_exposicion(self):
+        precio_cent_ton = (self.precio_cent_bu + self.base_cent_bu) * self.CONV_BU_TON
+        precio_usd_ton = precio_cent_ton / 100
+        precio_net = self.flete_usd_ton + precio_usd_ton
+        credito_subproductos = precio_net * self.CREDITO_PCT
+        precio_neto = precio_usd_ton + credito_subproductos
+        glucosa_materia = self.factor_maiz_glucosa * precio_neto
+        proc_fee_usd_ton = (self.proc_fee_cop_kg / self.trm) * 1000
+        precio_glucosa = proc_fee_usd_ton + self.processing_fee_usd + glucosa_materia
+        return self.ton_total * precio_glucosa
+
+    def to_dict(self):
+        base = super().to_dict()
+        precio_cent_ton = (self.precio_cent_bu + self.base_cent_bu) * self.CONV_BU_TON
+        precio_usd_ton = precio_cent_ton / 100
+        precio_net = self.flete_usd_ton + precio_usd_ton
+        credito_subproductos = precio_net * self.CREDITO_PCT
+        precio_neto = precio_usd_ton + credito_subproductos
+        glucosa_materia = self.factor_maiz_glucosa * precio_neto
+        proc_fee_usd_ton = (self.proc_fee_cop_kg / self.trm) * 1000
+        precio_glucosa = proc_fee_usd_ton + self.processing_fee_usd + glucosa_materia
+
+        base.update({
+            'exchange': 'CME - ZC',
+            'unidad_cotizacion': 'Centavos USD / Bushel',
+            'precio_futuro': self.precio_cent_bu,
+            'base_cent_bu': self.base_cent_bu,
+            'conv_bu_ton': self.CONV_BU_TON,
+            'precio_cent_ton': round(precio_cent_ton, 2),
+            'precio_usd_ton': round(precio_usd_ton, 4),
+            'flete_usd_ton': self.flete_usd_ton,
+            'precio_net': round(precio_net, 2),
+            'credito_subproductos': round(credito_subproductos, 2),
+            'precio_neto': round(precio_neto, 2),
+            'factor_maiz_glucosa': self.factor_maiz_glucosa,
+            'glucosa_materia': round(glucosa_materia, 2),
+            'processing_fee_usd': self.processing_fee_usd,
+            'proc_fee_cop_kg': self.proc_fee_cop_kg,
+            'trm': self.trm,
+            'proc_fee_usd_ton': round(proc_fee_usd_ton, 2),
+            'precio_glucosa': round(precio_glucosa, 2),
+        })
+        return base
+
+
+class CocoaDerivadoExposure(CommodityExposure):
+    """
+    Sección 5: COCOA - Polvo, Manteca y Licor (ICE CC)
+    Unidad: USD / Tonelada Métrica
+    Cada derivado tiene un factor de conversión diferente.
+    """
+    TON_CONTRATO = 10
+
+    def __init__(self, nombre, proyeccion_mensual, factor_conversion, precio_futuro_usd_ton):
+        super().__init__(nombre, proyeccion_mensual)
+        self.factor_conversion = factor_conversion
+        self.precio_futuro = precio_futuro_usd_ton
+
+    def calcular_exposicion(self):
+        kg_reales = self.ton_total * 1000 * self.factor_conversion
+        ton_reales = kg_reales / 1000
+        num_contratos = ton_reales / self.TON_CONTRATO
+        precio_x_contrato = self.TON_CONTRATO * self.precio_futuro
+        return num_contratos * precio_x_contrato
+
+    def to_dict(self):
+        base = super().to_dict()
+        kg_reales = self.ton_total * 1000 * self.factor_conversion
+        ton_reales = kg_reales / 1000
+        num_contratos = ton_reales / self.TON_CONTRATO
+        precio_x_contrato = self.TON_CONTRATO * self.precio_futuro
+
+        base.update({
+            'exchange': 'ICE - CC',
+            'unidad_cotizacion': 'USD / Tonelada Métrica',
+            'precio_futuro': self.precio_futuro,
+            'ton_contrato': self.TON_CONTRATO,
+            'factor_conversion': self.factor_conversion,
+            'kg_reales': round(kg_reales, 2),
+            'ton_reales': round(ton_reales, 2),
+            'num_contratos': round(num_contratos, 2),
+            'precio_x_contrato': round(precio_x_contrato, 2),
+        })
+        return base
+
+
+class EmpaqueExposure:
+    """
+    Sección 6: BOLSA ROLLO + ENVOLTURA EXTERNA (sin futuro)
+    Precio fijo × ton / TRM
+    """
+
+    def __init__(self, proyeccion_bolsa, proyeccion_envoltura, precio_total_fijo, trm=3800):
+        self.nombre = 'EMPAQUE'
+        self.proyeccion_bolsa = proyeccion_bolsa
+        self.proyeccion_envoltura = proyeccion_envoltura
+        self.ton_bolsa = sum(proyeccion_bolsa)
+        self.ton_envoltura = sum(proyeccion_envoltura)
+        self.precio_total_fijo = precio_total_fijo
+        self.trm = trm
+
+    def calcular_exposicion(self):
+        return self.precio_total_fijo * (self.ton_envoltura + self.ton_bolsa) / self.trm
+
+    def to_dict(self):
+        exposicion = self.calcular_exposicion()
+        return {
+            'nombre': self.nombre,
+            'exchange': 'N/A',
+            'unidad_cotizacion': 'Precio fijo / TRM',
+            'proyeccion_bolsa': self.proyeccion_bolsa,
+            'proyeccion_envoltura': self.proyeccion_envoltura,
+            'ton_bolsa': round(self.ton_bolsa, 2),
+            'ton_envoltura': round(self.ton_envoltura, 2),
+            'precio_total_fijo': self.precio_total_fijo,
+            'trm': self.trm,
+            'exposicion_usd': round(exposicion, 2),
+        }
+
+
+def calcular_exposicion_total(params):
+    """
+    Calcula la exposición total de la compañía.
+
+    params: dict con todos los inputs necesarios:
+      - proyeccion_azucar: list[12]
+      - precio_azucar_cent_lb: float
+      - factor_crudo_refinado: float (default 1.05)
+      - proyeccion_glucosa: list[12]
+      - precio_maiz_cent_bu: float
+      - base_maiz_cent_bu: float
+      - flete_usd_ton: float
+      - processing_fee_usd: float
+      - proc_fee_cop_kg: float
+      - trm: float
+      - factor_maiz_glucosa: float (default 1.495)
+      - proyeccion_cocoa_polvo: list[12]
+      - factor_cocoa_polvo: float (default 1.22)
+      - proyeccion_manteca: list[12]
+      - factor_manteca: float (default 1.95)
+      - proyeccion_licor: list[12]
+      - factor_licor: float (default 1.53)
+      - precio_cocoa_usd_ton: float
+      - proyeccion_bolsa: list[12]
+      - proyeccion_envoltura: list[12]
+      - precio_empaque_fijo: float
+      - ventas_intl_usd: float (optional)
+      - ventas_co_usd: float (optional)
+      - ventas_pe_usd: float (optional)
+    """
+    azucar = AzucarExposure(
+        params['proyeccion_azucar'],
+        params['precio_azucar_cent_lb'],
+        params.get('factor_crudo_refinado', 1.05),
+    )
+
+    maiz = MaizGlucosaExposure(
+        params['proyeccion_glucosa'],
+        params['precio_maiz_cent_bu'],
+        params['base_maiz_cent_bu'],
+        params['flete_usd_ton'],
+        params['processing_fee_usd'],
+        params['proc_fee_cop_kg'],
+        params['trm'],
+        params.get('factor_maiz_glucosa', 1.495),
+    )
+
+    polvo = CocoaDerivadoExposure(
+        'COCOA_POLVO',
+        params['proyeccion_cocoa_polvo'],
+        params.get('factor_cocoa_polvo', 1.22),
+        params['precio_cocoa_usd_ton'],
+    )
+
+    manteca = CocoaDerivadoExposure(
+        'MANTECA_CACAO',
+        params['proyeccion_manteca'],
+        params.get('factor_manteca', 1.95),
+        params['precio_cocoa_usd_ton'],
+    )
+
+    licor = CocoaDerivadoExposure(
+        'LICOR_CACAO',
+        params['proyeccion_licor'],
+        params.get('factor_licor', 1.53),
+        params['precio_cocoa_usd_ton'],
+    )
+
+    empaque = EmpaqueExposure(
+        params['proyeccion_bolsa'],
+        params['proyeccion_envoltura'],
+        params['precio_empaque_fijo'],
+        params.get('trm', 3800),
+    )
+
+    commodities = [azucar, maiz, polvo, manteca, licor, empaque]
+    total_commodities = sum(c.calcular_exposicion() for c in commodities)
+
+    # Exposición USD: Ventas Internacionales - Exposición del mes (sum commodities)
+    ventas_intl = params.get('ventas_intl_usd', 0)
+    ventas_co = params.get('ventas_co_usd', 0)
+    ventas_pe = params.get('ventas_pe_usd', 0)
+    exposicion_ventas = ventas_intl
+    exposicion_real_usd = ventas_intl - total_commodities
+
+    return {
+        'commodities': [c.to_dict() for c in commodities],
+        'total_commodities_usd': round(total_commodities, 2),
+        'exposicion_ventas_intl': round(exposicion_ventas, 2),
+        'exposicion_real_usd': round(exposicion_real_usd, 2),
+        'exposicion_pen': round(ventas_pe, 2),
+    }

--- a/gestion_de_riesgos/var_engine/var_calculator.py
+++ b/gestion_de_riesgos/var_engine/var_calculator.py
@@ -3,29 +3,30 @@ import pandas as pd
 from scipy.stats import norm
 
 
-CONFIDENCE_LEVEL = 0.95
+DEFAULT_CONFIDENCE = 0.99
 ROLLING_WINDOW = 180
-Z_SCORE = norm.ppf(CONFIDENCE_LEVEL)
 
 
 class VaRCalculator:
     """
     Calcula Value at Risk (VaR) parametrico diario usando volatilidad rolling.
     - Ventana rolling: 180 dias
-    - Nivel de confianza: 95%
+    - Nivel de confianza: configurable (default 99%)
     - Metodo: VaR parametrico (varianza-covarianza)
     """
 
-    def __init__(self, prices: pd.DataFrame, window: int = ROLLING_WINDOW):
+    def __init__(self, prices: pd.DataFrame, window: int = ROLLING_WINDOW,
+                 confidence_level: float = DEFAULT_CONFIDENCE):
         """
         Args:
             prices: DataFrame con columna 'date' y columnas de precios por activo.
-                    Ejemplo columnas: ['date', 'MAIZ', 'AZUCAR', 'CACAO', 'USD']
             window: Ventana rolling en dias para calcular volatilidad.
+            confidence_level: Nivel de confianza (0.90, 0.95, 0.99).
         """
         self.prices = prices.copy()
         self.window = window
-        self.z_score = Z_SCORE
+        self.confidence_level = confidence_level
+        self.z_score = norm.ppf(confidence_level)
         self.returns = None
         self.volatilities = None
 

--- a/server/risk_management_server/risk_management_server.py
+++ b/server/risk_management_server/risk_management_server.py
@@ -16,6 +16,8 @@ class RiskManagementServer(XerenityFunctionServer):
         self.filter_date = body['filter_date']
         self.portfolio_id = body.get('portfolio_id', None)
         self.mock = body.get('mock', False)
+        self.exposure_params = body.get('exposure_params', None)
+        self.confidence_level = body.get('confidence_level', 0.99)
 
     def calculate(self):
         """
@@ -210,7 +212,7 @@ class RiskManagementServer(XerenityFunctionServer):
         - price_start: precio inicio del mes anterior
         - price_end: precio fin del mes anterior
         """
-        from gestion_de_riesgos.db_risk import get_risk_prices
+        from gestion_de_riesgos.db_risk import get_risk_prices, get_risk_contracts
         from gestion_de_riesgos.var_engine.var_calculator import VaRCalculator
         from datetime import datetime, timedelta
         import pandas as pd
@@ -240,21 +242,30 @@ class RiskManagementServer(XerenityFunctionServer):
             )
 
         # Factor VaR diario (ultimo dia disponible)
-        calc = VaRCalculator(prices_df, window=180)
+        calc = VaRCalculator(prices_df, window=180, confidence_level=self.confidence_level)
         factors = calc.get_latest_var_factors()
 
-        # Retornos logaritmicos y varianza/covarianza
+        # Retornos logaritmicos independientes por activo
         import numpy as np
-        calc.calculate_returns()
-        returns_df = calc.returns.copy()
         prices_df['date'] = pd.to_datetime(prices_df['date'])
         price_cols = [c for c in prices_df.columns if c != 'date']
 
-        # Matriz de covarianza de retornos (ultimos 180 dias)
-        returns_only = returns_df[price_cols].dropna()
-        if len(returns_only) > 180:
-            returns_only = returns_only.tail(180)
-        cov_matrix = returns_only.cov()
+        # Returns independientes: cada activo usa solo sus dias con precio real
+        returns_indep = pd.DataFrame(index=prices_df.index)
+        for col in price_cols:
+            series = prices_df[col].dropna()
+            returns_indep[col] = np.log(series / series.shift(1))
+
+        # Ultimas 180 filas del indice (rango temporal)
+        returns_window = returns_indep.tail(180)
+
+        # Covarianza pairwise: cada par usa los dias donde ambos tienen return
+        cov_matrix = returns_window.cov(min_periods=20)
+
+        # Rango real de datos y observaciones por activo
+        cov_start = str(prices_df['date'].iloc[returns_window.index[0]])[:10]
+        cov_end = str(prices_df['date'].iloc[returns_window.index[-1]])[:10]
+        cov_obs_per_asset = {col: int(returns_window[col].notna().sum()) for col in price_cols}
 
         # Serializar matriz de covarianza
         cov_dict = {}
@@ -270,8 +281,8 @@ class RiskManagementServer(XerenityFunctionServer):
             val = cov_matrix.loc[col, col]
             daily_variance[col] = round(float(val), 10) if not np.isnan(val) else None
 
-        # Matriz de correlacion
-        corr_matrix = returns_only.corr()
+        # Matriz de correlacion (pairwise)
+        corr_matrix = returns_window.corr(min_periods=20)
         corr_dict = {}
         for row_asset in price_cols:
             corr_dict[row_asset] = {}
@@ -281,28 +292,35 @@ class RiskManagementServer(XerenityFunctionServer):
 
         units = {'MAIZ': 'TONS', 'AZUCAR': 'TONS', 'CACAO': 'TONS', 'USD': 'USD/COP'}
 
-        # Precios hardcoded (31-ene-26 y 27-feb-26)
-        hardcoded_prices = {
-            'MAIZ':   {'price_start': 435.750, 'price_end': 448.50},
-            'AZUCAR': {'price_start': 13.84,   'price_end': 13.89},
-            'CACAO':  {'price_start': 4.162,   'price_end': 2.798},
-            'USD':    {'price_start': 3670.47,  'price_end': 3745.78},
-        }
-
         def clean(v):
             if v is None or (isinstance(v, float) and math.isnan(v)):
                 return None
             return v
 
+        def find_price(df, col, target_date):
+            """Find the closest available price on or before target_date."""
+            mask = df['date'] <= target_date.strftime('%Y-%m-%d')
+            subset = df.loc[mask, ['date', col]].dropna(subset=[col])
+            if subset.empty:
+                return None
+            return round(float(subset.iloc[-1][col]), 4)
+
+        contracts = get_risk_contracts(
+            initial_date=start_history.strftime('%Y-%m-%d'),
+            final_date=price_end_date.strftime('%Y-%m-%d')
+        )
+
         result = {}
         for col in price_cols:
-            hc = hardcoded_prices.get(col, {})
+            p_start = find_price(prices_df, col, price_start_date)
+            p_end = find_price(prices_df, col, price_end_date)
             result[col] = {
                 'factor_var_diario': clean(factors.get(col, 0)),
                 'daily_variance': daily_variance.get(col),
-                'price_start': hc.get('price_start'),
-                'price_end': hc.get('price_end'),
+                'price_start': p_start,
+                'price_end': p_end,
                 'factor_unit': units.get(col, ''),
+                'contract': contracts.get(col),
             }
 
         return responseHttpOk(body={
@@ -310,10 +328,18 @@ class RiskManagementServer(XerenityFunctionServer):
             'covariance_matrix': cov_dict,
             'correlation_matrix': corr_dict,
             'assets': price_cols,
+            'contracts': contracts,
             'period': {
                 'start': price_start_date.strftime('%Y-%m-%d'),
                 'end': price_end_date.strftime('%Y-%m-%d'),
-            }
+            },
+            'covariance_period': {
+                'start': cov_start,
+                'end': cov_end,
+                'observations': cov_obs_per_asset,
+            },
+            'confidence_level': self.confidence_level,
+            'z_score': round(float(calc.z_score), 4),
         })
 
     def rolling_var(self):
@@ -324,10 +350,11 @@ class RiskManagementServer(XerenityFunctionServer):
             {
                 "dates": ["2025-06-01", ...],
                 "prices": {"MAIZ": [...], "AZUCAR": [...], ...},
-                "rolling_var": {"MAIZ": [...], "AZUCAR": [...], ...}
+                "rolling_var": {"MAIZ": [...], "AZUCAR": [...], ...},
+                "contracts": {"MAIZ": "ZCH26", ...}
             }
         """
-        from gestion_de_riesgos.db_risk import get_risk_prices
+        from gestion_de_riesgos.db_risk import get_risk_prices, get_risk_contracts
         from gestion_de_riesgos.var_engine.var_calculator import VaRCalculator
         from datetime import datetime, timedelta
         import math
@@ -346,7 +373,12 @@ class RiskManagementServer(XerenityFunctionServer):
                 code=404
             )
 
-        calc = VaRCalculator(prices_df, window=180)
+        contracts = get_risk_contracts(
+            initial_date=start_date.strftime('%Y-%m-%d'),
+            final_date=self.filter_date
+        )
+
+        calc = VaRCalculator(prices_df, window=180, confidence_level=self.confidence_level)
         var_factors = calc.calculate_var_factor()
 
         dates = prices_df['date'].tolist()
@@ -362,7 +394,6 @@ class RiskManagementServer(XerenityFunctionServer):
                 None if (v is None or (isinstance(v, float) and math.isnan(v))) else round(v, 4)
                 for v in price_list
             ]
-            # VaR en USD = var_factor * precio (var_factor ya incluye Z * volatilidad)
             rolling_var_dict[col] = [
                 None if (v is None or p is None or
                          (isinstance(v, float) and math.isnan(v)) or
@@ -375,4 +406,140 @@ class RiskManagementServer(XerenityFunctionServer):
             'dates': dates,
             'prices': prices_dict,
             'rolling_var': rolling_var_dict,
+            'contracts': contracts,
         })
+
+    def collectors_status(self):
+        """
+        Retorna el estado de los collectors y calendario de contratos.
+        Incluye fechas de vencimiento, roll, y contrato front actual.
+        """
+        from gestion_de_riesgos.collectors.base_collector import (
+            COLLECTORS, COMMODITY_CONFIG, JSON_PATHS,
+            FuturesJSONCollector, get_collectors_status,
+        )
+
+        status = get_collectors_status()
+
+        # Agregar calendario de contratos para cada commodity
+        for asset_name in ['MAIZ', 'AZUCAR', 'CACAO']:
+            if asset_name in COMMODITY_CONFIG and asset_name in JSON_PATHS:
+                collector = FuturesJSONCollector(
+                    asset_name, JSON_PATHS[asset_name], COMMODITY_CONFIG[asset_name]
+                )
+                schedule = collector.get_contract_schedule()
+                if asset_name in status:
+                    status[asset_name]['schedule'] = schedule
+
+        return responseHttpOk(body=status)
+
+    def update_prices(self):
+        """
+        Actualiza precios en Supabase leyendo de los JSON locales.
+        Usa la nueva logica de roll con fechas de expiracion reales.
+
+        Request body:
+            {
+                "filter_date": "2026-03-17",
+                "assets": ["MAIZ", "AZUCAR", "CACAO", "USD"]  // opcional, default: todos
+            }
+        """
+        from gestion_de_riesgos.collectors.base_collector import (
+            COLLECTORS, collect_all,
+        )
+        from datetime import datetime, timedelta
+
+        end_date = self.filter_date
+        ref = datetime.strptime(end_date, '%Y-%m-%d')
+        start_date = (ref - timedelta(days=365)).strftime('%Y-%m-%d')
+
+        results = collect_all(start_date, end_date)
+        return responseHttpOk(body=results)
+
+    def exposure(self):
+        """
+        Calcula la exposición en USD por commodity.
+
+        Request body (además de filter_date):
+            {
+                "filter_date": "2026-03-12",
+                "exposure_params": {
+                    "proyeccion_azucar": [3157, 3157, ...],  // 12 meses
+                    "precio_azucar_cent_lb": 13.89,
+                    "factor_crudo_refinado": 1.05,
+                    "proyeccion_glucosa": [2277, 2277, ...],
+                    "precio_maiz_cent_bu": 442,
+                    "base_maiz_cent_bu": 80,
+                    "flete_usd_ton": 46,
+                    "processing_fee_usd": 263,
+                    "proc_fee_cop_kg": 668,
+                    "trm": 3800,
+                    "factor_maiz_glucosa": 1.495,
+                    "proyeccion_cocoa_polvo": [24, 24, ...],
+                    "factor_cocoa_polvo": 1.22,
+                    "proyeccion_manteca": [13, 13, ...],
+                    "factor_manteca": 1.95,
+                    "proyeccion_licor": [4, 4, ...],
+                    "factor_licor": 1.53,
+                    "precio_cocoa_usd_ton": 2798,
+                    "proyeccion_bolsa": [151, 151, ...],
+                    "proyeccion_envoltura": [138, 138, ...],
+                    "precio_empaque_fijo": 21610000,
+                    "ventas_intl_usd": 130025826,
+                    "ventas_co_usd": 0,
+                    "ventas_pe_usd": 42827644
+                }
+            }
+        """
+        from gestion_de_riesgos.exposure import calcular_exposicion_total
+        from gestion_de_riesgos.db_risk import get_risk_prices, get_risk_contracts
+        from datetime import datetime, timedelta
+
+        params = self.exposure_params
+        if not params:
+            raise XerenityError(
+                message="Missing exposure_params in request body",
+                code=400
+            )
+
+        # Fetch latest futures prices from Supabase
+        ref_date = datetime.strptime(self.filter_date, '%Y-%m-%d')
+        start_fetch = ref_date - timedelta(days=60)
+        prices_df = get_risk_prices(
+            initial_date=start_fetch.strftime('%Y-%m-%d'),
+            final_date=self.filter_date
+        )
+
+        contracts = get_risk_contracts(
+            initial_date=start_fetch.strftime('%Y-%m-%d'),
+            final_date=self.filter_date
+        )
+
+        market_prices = {}
+        if not prices_df.empty:
+            # Map DB columns to exposure params
+            price_map = {
+                'AZUCAR': 'precio_azucar_cent_lb',
+                'MAIZ': 'precio_maiz_cent_bu',
+                'CACAO': 'precio_cocoa_usd_ton',
+                'USD': 'trm',
+            }
+            for db_col, param_key in price_map.items():
+                if db_col in prices_df.columns:
+                    col_data = prices_df[['date', db_col]].dropna(subset=[db_col])
+                    if not col_data.empty:
+                        last_row = col_data.iloc[-1]
+                        price_val = float(last_row[db_col])
+                        price_date = str(last_row['date'])
+                        market_prices[param_key] = {
+                            'value': round(price_val, 4),
+                            'date': price_date,
+                            'source': db_col,
+                            'contract': contracts.get(db_col),
+                        }
+                        # Override param with DB price
+                        params[param_key] = price_val
+
+        result = calcular_exposicion_total(params)
+        result['market_prices'] = market_prices
+        return responseHttpOk(body=result)

--- a/xerenity_functions/urls.py
+++ b/xerenity_functions/urls.py
@@ -177,6 +177,39 @@ def risk_benchmark_factors(request):
         return responseHttpError(message=str(e), code=400)
 
 
+def risk_exposure(request):
+    try:
+        from server.risk_management_server.risk_management_server import RiskManagementServer
+        calc = RiskManagementServer(json.loads(request.body))
+        return calc.exposure()
+    except XerenityError as xerror:
+        return responseHttpError(message=xerror.message, code=xerror.code)
+    except Exception as e:
+        return responseHttpError(message=str(e), code=400)
+
+
+def risk_collectors_status(request):
+    try:
+        from server.risk_management_server.risk_management_server import RiskManagementServer
+        calc = RiskManagementServer(json.loads(request.body))
+        return calc.collectors_status()
+    except XerenityError as xerror:
+        return responseHttpError(message=xerror.message, code=xerror.code)
+    except Exception as e:
+        return responseHttpError(message=str(e), code=400)
+
+
+def risk_update_prices(request):
+    try:
+        from server.risk_management_server.risk_management_server import RiskManagementServer
+        calc = RiskManagementServer(json.loads(request.body))
+        return calc.update_prices()
+    except XerenityError as xerror:
+        return responseHttpError(message=xerror.message, code=xerror.code)
+    except Exception as e:
+        return responseHttpError(message=str(e), code=400)
+
+
 def wake_up(request):
     return responseHttpOk(body={"message": "Servidor de creditos activado"})
 
@@ -194,6 +227,9 @@ urlpatterns = [
     path("risk_management", csrf_exempt(risk_management), name="risk_management"),
     path("risk_rolling_var", csrf_exempt(risk_rolling_var), name="risk_rolling_var"),
     path("risk_benchmark_factors", csrf_exempt(risk_benchmark_factors), name="risk_benchmark_factors"),
+    path("risk_exposure", csrf_exempt(risk_exposure), name="risk_exposure"),
+    path("risk_collectors_status", csrf_exempt(risk_collectors_status), name="risk_collectors_status"),
+    path("risk_update_prices", csrf_exempt(risk_update_prices), name="risk_update_prices"),
     # Pricing API
     path("pricing/curves/build", pricing_build, name="pricing_build"),
     path("pricing/curves/status", pricing_status, name="pricing_status"),


### PR DESCRIPTION
## Summary
- Replace month-based futures roll logic with real expiry dates per exchange (CBOT 14th, ICE Sugar last day of prior month, ICE Cocoa 14th) with configurable `roll_days_before`
- Fix exposure: Real USD = Ventas Intl - Total Commodities
- Make VaR confidence level configurable (default 99%)
- Use independent pairwise returns for covariance (instead of dropna/ffill)
- Fix `upsert_risk_prices` with `on_conflict='date,asset'`
- Add `collectors_status` and `update_prices` endpoints
- Updated Supabase with new front contracts: ZCK26, SBK6, CCK26

Closes #66

## Test plan
- [x] Verified new roll logic selects correct contracts (ZCK26, SBK6, CCK26)
- [x] Verified MAIZ price Feb 27 = 448.50 matches user's Excel
- [x] Verified 242 records per commodity uploaded to Supabase
- [x] Verified frontend endpoints (`benchmark_factors`, `rolling_var`, `exposure`) don't import collectors (no Fly.dev path issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)