### PR TITLE
fix(deploy): correct Fly.io app name (#66)

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -3,7 +3,7 @@
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = "xerenity-pysdk"
+app = "pysdk"
 primary_region = "dfw"
 console_command = "/code/manage.py shell"
 


### PR DESCRIPTION
## Summary
- Fix fly.toml app name from `xerenity-pysdk` to `pysdk` to match actual Fly.io app name
- This was causing all deploys to fail with `unauthorized` since the deploy token is scoped to `pysdk`

Closes #66

## Test plan
- [x] Verified app name `pysdk` in Fly.io dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)