### PR TITLE
chore(ci): add workflow_dispatch + trigger deploy

### DIFF
--- a/.github/workflows/flyio.yaml
+++ b/.github/workflows/flyio.yaml
@@ -2,7 +2,8 @@ name: Fly Deploy
 on:
   push:
     branches:
-      - main    # change to main if needed
+      - main
+  workflow_dispatch:  # allow manual trigger from GitHub UI
 jobs:
   deploy:
     name: Deploy app


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to Fly Deploy workflow so deploys can be triggered manually from GitHub Actions UI
- This push to main will also trigger the auto-deploy with the multi-tenant auth changes
#76
## Why

Deploy from local machine fails due to recurring DNS issues. CI/CD via GitHub Actions is the reliable long-term solution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)