### PR TITLE
fix(ci): force no-cache deploy to Fly.io

### DIFF
--- a/.github/workflows/flyio.yaml
+++ b/.github/workflows/flyio.yaml
@@ -12,6 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only
+      - run: flyctl deploy --remote-only --no-cache
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary
#78
Adds `--no-cache` flag to `flyctl deploy` in GitHub Actions workflow.

Fly.io was caching Docker layers and serving stale code despite successful deploys. The auth-optional fix (PR #77) was merged but never actually deployed because the `COPY . /code` layer was cached.

## Test plan
- [ ] Deploy completes and backend responds without requiring auth token
- [ ] Remove `--no-cache` flag after confirming deployment works

🤖 Generated with [Claude Code](https://claude.com/claude-code)