### PR TITLE
fix(pricing): reprice FX spot from market_marks, not currency_hour

### DIFF
--- a/backfill_feb_mar_2026_marks.py
+++ b/backfill_feb_mar_2026_marks.py
@@ -132,7 +132,8 @@ def main():
         # ── Fetch real market data for this date ──
         ibr_quotes = loader.fetch_ibr_quotes(target_date=fecha)
         sofr_df    = loader.fetch_sofr_curve(target_date=fecha)
-        fx_spot    = loader.fetch_usdcop_spot(target_date=fecha)
+        # Backfill job — use live SET-ICAP tick, not market_marks (we're building the mark).
+        fx_spot    = loader.fetch_usdcop_spot_live(target_date=fecha)
         sofr_on    = loader.fetch_sofr_spot(target_date=fecha)
 
         # ── FX Spot: carry forward if missing ──

--- a/pricing/data/market_data.py
+++ b/pricing/data/market_data.py
@@ -172,15 +172,53 @@ class MarketDataLoader:
 
     def fetch_usdcop_spot(self, target_date: str = None) -> Optional[float]:
         """
-        Fetch latest USD/COP spot rate.
+        Fetch USD/COP spot rate for pricing/valuation.
 
-        Primary source: currency_hour table (SET-ICAP intraday prices).
-          - Live: last trade of the day.
-          - Historical (target_date provided): last trade of that date.
+        IMPORTANT: For portfolio valuation we MUST use the frozen EOD spot
+        stored in market_marks.fx_spot (the same value shown in the Marks
+        tab of the frontend). Otherwise the portfolio "jumps" every time
+        currency_hour receives a new intraday tick from SET-ICAP.
 
-        Fallback: cop_fwd_points SN tenor mid (FXEmpire), used when
-        currency_hour has no data for the requested date (e.g. weekends,
-        dates before the SET-ICAP collector was live).
+        Resolution order:
+          1. market_marks.fx_spot for target_date (frozen EOD snapshot)
+          2. market_marks.fx_spot for latest available date (if target_date
+             is None or has no mark yet)
+          3. currency_hour last trade (only for the live/latest path when
+             no market_marks row exists yet — e.g. intraday before the
+             EOD compute job has run)
+          4. cop_fwd_points SN tenor mid (FXEmpire) as final fallback
+
+        Use fetch_usdcop_spot_live() explicitly if you need the raw SET-ICAP
+        tick (e.g. inside run_compute_marks.py when computing a new mark).
+        """
+        # 1. Try the requested date from market_marks
+        if target_date is not None:
+            marks_data = self._get(
+                "market_marks",
+                f"select=fx_spot&fecha=eq.{target_date}&limit=1",
+            )
+            if marks_data and marks_data[0].get("fx_spot") is not None:
+                return float(marks_data[0]["fx_spot"])
+
+        # 2. Fall back to latest market_marks row
+        latest = self._get(
+            "market_marks",
+            "select=fx_spot&order=fecha.desc&limit=1",
+        )
+        if latest and latest[0].get("fx_spot") is not None:
+            return float(latest[0]["fx_spot"])
+
+        # 3. No EOD mark available — use live SET-ICAP tick as last resort
+        value = self._fetch_usdcop_setfx(target_date)
+        if value is not None:
+            return value
+        return self._fetch_usdcop_fwd_points_sn(target_date)
+
+    def fetch_usdcop_spot_live(self, target_date: str = None) -> Optional[float]:
+        """
+        Fetch raw USD/COP spot directly from SET-ICAP (currency_hour table),
+        bypassing market_marks. Used by run_compute_marks.py to build a new
+        daily mark from the latest intraday tick.
         """
         value = self._fetch_usdcop_setfx(target_date)
         if value is not None:

--- a/run_backfill_marks.py
+++ b/run_backfill_marks.py
@@ -115,7 +115,8 @@ def main():
         fills = []
 
         # ── FX spot ──
-        fx_spot = loader.fetch_usdcop_spot(target_date=fecha)
+        # Backfill builds new marks — use live SET-ICAP tick, not market_marks.
+        fx_spot = loader.fetch_usdcop_spot_live(target_date=fecha)
         if fx_spot is None:
             fx_spot = last["fx_spot"]
             fills.append("spot")

--- a/run_compute_marks.py
+++ b/run_compute_marks.py
@@ -36,7 +36,8 @@ def compute_marks(target_date: str = None) -> dict:
     # ── Fetch ──
     ibr_quotes = loader.fetch_ibr_quotes(target_date=target_date)
     sofr_df    = loader.fetch_sofr_curve(target_date=target_date)
-    fx_spot    = loader.fetch_usdcop_spot(target_date=target_date)
+    # Use live SET-ICAP tick here — this is the job that WRITES the mark.
+    fx_spot    = loader.fetch_usdcop_spot_live(target_date=target_date)
     cop_fwd    = loader.fetch_cop_forwards(target_date=target_date)
     sofr_on    = loader.fetch_sofr_spot(target_date=target_date)
 


### PR DESCRIPTION
Closes #86

## Problema
El portafolio OTC en el frontend muestra una barra de marcas con `fx_spot` tomado de `xerenity.market_marks` (valor EOD congelado por `run_compute_marks.py`). Sin embargo, cuando el frontend llama a `/pricing/reprice-portfolio`, el backend llamaba a `loader.fetch_usdcop_spot()`, que leia el **ultimo tick intradia** de `currency_hour` (SET-ICAP).

Cada nueva cotizacion que entraba en `currency_hour` cambiaba el spot usado por el repricer → **los NPVs saltaban visiblemente** cada vez que la pagina se refrescaba o tras cierto tiempo, aunque la barra de marcas mostrara el mismo valor.

## Solucion
`fetch_usdcop_spot()` ahora lee **primero** `market_marks.fx_spot` (misma fuente que la tab Marcas). Solo cae a `currency_hour` si no hay ningun mark disponible.

Se agrega `fetch_usdcop_spot_live()` con el comportamiento viejo (tick intradia directo) para uso exclusivo de los jobs que **construyen** los marks:
- `run_compute_marks.py`
- `run_backfill_marks.py`
- `backfill_feb_mar_2026_marks.py`

Sin esto tendriamos un loop circular (el job que escribe el mark no puede leerse a si mismo).

## Verificacion local
- `market_marks.fx_spot` (2026-04-07) = **3680**
- `/pricing/curves/build` retorna `fx_spot: 3680.0`
- 3 builds consecutivas → spot estable en 3680.0 (antes brincaba)
- `/pricing/reprice-portfolio` NDF → `spot: 3680.0`
- Match exacto entre barra de marcas y repricer

## Resultado
- `/pricing/curves/build` → spot = market_marks.fx_spot
- `/pricing/reprice-portfolio` (live) → spot = market_marks.fx_spot
- `/pricing/reprice-portfolio` (con `valuation_date`) → ya usaba `_fetch_historical_spot()`, sigue igual
- Los jobs EOD siguen leyendo el tick vivo de SET-ICAP

🤖 Generated with [Claude Code](https://claude.com/claude-code)