### PR TITLE
feat(usdcop): USDCOP calculator endpoint

### DIFF
--- a/server/usdcop_calculator/usdcop_calculator.py
+++ b/server/usdcop_calculator/usdcop_calculator.py
@@ -1,0 +1,73 @@
+import os
+import math
+
+import numpy as np
+import pandas as pd
+import requests
+
+from server.main_server import XerenityError, responseHttpOk
+
+
+TRADING_DAYS = 252
+VOL_WINDOW = 180
+FETCH_LIMIT = 250
+BANREP_TRM_ID_SERIE = 25
+
+
+class UsdCopCalculator:
+    """Calcula TRM spot y volatilidad (diaria/anual) desde BanRep via Supabase REST."""
+
+    def calculate(self):
+        url = os.getenv("XTY_URL")
+        key = os.getenv("XTY_TOKEN")
+        bearer = os.getenv("COLLECTOR_BEARER") or key
+
+        if not url or not key:
+            raise XerenityError("XTY_URL / XTY_TOKEN no configuradas", 500)
+
+        session = requests.Session()
+        session.headers.update({
+            "apikey": key,
+            "Authorization": f"Bearer {bearer}",
+            "Accept-Profile": "xerenity",
+        })
+
+        resp = session.get(
+            f"{url}/rest/v1/banrep_series_value_v2"
+            f"?select=fecha,valor"
+            f"&id_serie=eq.{BANREP_TRM_ID_SERIE}"
+            f"&order=fecha.desc"
+            f"&limit={FETCH_LIMIT}",
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        if not data:
+            raise XerenityError("No se encontraron datos de TRM en banrep_series_value_v2", 404)
+
+        df = pd.DataFrame(data)
+        df["valor"] = pd.to_numeric(df["valor"], errors="coerce")
+        df = df.dropna(subset=["valor"]).sort_values("fecha").reset_index(drop=True)
+
+        if len(df) < 2:
+            raise XerenityError("Datos insuficientes de TRM para calcular retornos", 400)
+
+        log_returns = np.log(df["valor"] / df["valor"].shift(1)).dropna()
+
+        window = log_returns.tail(VOL_WINDOW)
+        if len(window) < 30:
+            raise XerenityError(
+                f"Datos insuficientes para vol rolling: {len(window)} retornos (min 30)",
+                400,
+            )
+
+        vol_diaria = float(window.std())
+        vol_anual = vol_diaria * math.sqrt(TRADING_DAYS)
+
+        return responseHttpOk(body={
+            "trm": float(df["valor"].iloc[-1]),
+            "vol_diaria": vol_diaria,
+            "vol_anual": vol_anual,
+            "fecha": str(df["fecha"].iloc[-1]),
+        })

--- a/xerenity_functions/urls.py
+++ b/xerenity_functions/urls.py
@@ -211,6 +211,16 @@ def wake_up(request):
     return responseHttpOk(body={"message": "Servidor de creditos activado", "version": "2026-04-01-auth-optional"})
 
 
+def usdcop_calculator(request):
+    try:
+        from server.usdcop_calculator.usdcop_calculator import UsdCopCalculator
+        return UsdCopCalculator().calculate()
+    except XerenityError as xerror:
+        return responseHttpError(message=xerror.message, code=xerror.code)
+    except Exception as e:
+        return responseHttpError(message=str(e), code=400)
+
+
 urlpatterns = [
     path("period_payment", csrf_exempt(period_payment), name="period_payment"),
     path("cash_flow", csrf_exempt(cash_flow), name="cash_flow"),
@@ -221,6 +231,7 @@ urlpatterns = [
     path("all_loans", csrf_exempt(all_loans), name="all_loans"),
     path("uvr_rates", csrf_exempt(uvr_rates), name="uvr_rates"),
     path("wake_up", csrf_exempt(wake_up), name="wake_up"),
+    path("usdcop_calculator", csrf_exempt(usdcop_calculator), name="usdcop_calculator"),
     path("risk_management", csrf_exempt(risk_management), name="risk_management"),
     path("risk_rolling_var", csrf_exempt(risk_rolling_var), name="risk_rolling_var"),
     path("risk_benchmark_factors", csrf_exempt(risk_benchmark_factors), name="risk_benchmark_factors"),


### PR DESCRIPTION
Closes #95

## Summary
Nuevo endpoint \`GET /usdcop_calculator\` que calcula la volatilidad historica de la TRM (USDCOP) desde BanRep.

## Implementacion
- **Archivo:** \`server/usdcop_calculator/usdcop_calculator.py\`
- **Registrado en:** \`xerenity_functions/urls.py\` con \`csrf_exempt\`
- **Fuente de datos:** \`xerenity.banrep_series_value_v2\` (id_serie=25, TRM)
- **Ventana:** 180 dias habiles
- **Calculos:**
  * TRM = ultimo valor de la serie
  * log_returns = ln(valor[t] / valor[t-1])
  * vol_diaria = std(last 180 log_returns)
  * vol_anual = vol_diaria × sqrt(252)

## Respuesta
\`\`\`json
{
  "trm": 3603.19,
  "vol_diaria": 0.00575179508004653,
  "vol_anual": 0.09130691624404781,
  "fecha": "2026-04-16T00:00:00"
}
\`\`\`

## Consumidor
El frontend xerenity-fe tiene el PR #265 que usa este endpoint desde el nuevo tab "Calculadora USDCOP" en /risk-management.

## Test plan
- [ ] Deploy a Fly.io
- [ ] \`curl https://pysdk.fly.dev/usdcop_calculator\` responde 200 con los 4 campos
- [ ] Frontend carga datos reales al abrir el tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)