### PR TITLE
docs(risk): Super de Alimentos formulations (AKOMEL/CEBES/ALMIDON)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -581,12 +581,86 @@ La pantalla de setup de commodities ahora permite guardar con **0 commodities**
 - Si el asset seleccionado ya no esta en la lista (cambio de empresa),
   se reemplaza automaticamente por el primero disponible
 
+### Resumen Exposicion Compañia — fix de campos (abril 2026)
+
+Bug en `fetchExposure` (`src/models/risk/riskApi.ts`): el resumen mostraba
+"Exposición Ventas Intl." igual al valor de "Exposición Real USD" aunque
+el input del usuario era distinto. Ejemplo concreto con Super de Alimentos:
+- Input Ventas Intl. (USD): `130,025,826`
+- Card mostraba: `82,693,807` (incorrecto, era el Real USD)
+
+**Causa:** el fetcher asignaba `exposicion_ventas_intl: result.exposicion_real_usd`
+en vez de `result.ventas_intl_usd`. Ademas `exposicion_pen` estaba hardcoded a 0.
+
+**Fix (mismo archivo, funcion `fetchExposure`):**
+```ts
+exposicion_ventas_intl: result.ventas_intl_usd,  // antes: result.exposicion_real_usd
+exposicion_pen:         result.ventas_pe_usd,    // antes: 0
+```
+
+**Formula segun la metodologia (tab Exposicion):**
+```
+Exposicion Real USD = Ventas Internacionales (USD) − Total Commodities (USD)
+```
+Para Super: `82,693,807 = 130,025,826 − 47,332,019` ✓
+
+### MAÍZ / GLUCOSA — calculo de # Contratos (abril 2026)
+
+Antes el card MAÍZ/GLUCOSA en el tab Exposicion no mostraba el numero de
+contratos de futuros CBOT ZC necesarios para cubrir la proyeccion de glucosa.
+Ademas las filas de "Precio Maíz (¢/ton)", "Precio Maíz (USD/ton)", "Crédito
+Subproductos", "Glucosa Materia", "Precio Glucosa" mostraban "—" porque el
+UI accedia a `mz.precio_usd_ton` pero el calculador los guarda en
+`mz.detalle.precio_usd_ton`.
+
+**Cambios en `src/lib/risk/exposureCalculator.ts`:**
+
+Constantes nuevas:
+```ts
+const TON_PER_BUSHEL = 0.0254;              // 1 bushel de maiz = 25.4 kg
+const CORN_BUSHELS_CONTRATO = 5000;         // CBOT Corn futures = 5,000 bu
+const CORN_TON_CONTRATO = 5000 × 0.0254;    // = 127 toneladas/contrato
+```
+
+Calculo correcto de # contratos en `calcularMaiz()`:
+```
+TON Maíz reales = TON Glucosa (proyeccion) × Factor Maíz→Glucosa
+                = 27,324 × 1.495
+                = 40,849 toneladas
+
+# Contratos   = TON Maíz reales ÷ TON Contrato CBOT ZC
+              = 40,849 ÷ 127
+              = 321.65 contratos
+```
+
+**Interpretacion:** si Super quisiera cobertura 100% de su exposicion al precio
+del maiz, tendria que comprar ~322 contratos ZC en CBOT. Es el equivalente al
+calculo que ya existia para AZUCAR (~783 contratos).
+
+`detalle` del `CommodityExposure` ahora incluye: `precio_cent_ton`,
+`precio_glucosa`, `ton_contrato` (127), `factor_maiz_glucosa`. Antes solo
+estaban `precio_usd_ton`, `credito_subproductos`, `glucosa_materia`, etc.
+
+UI actualizado en `risk-management/index.tsx` para leer desde
+`mz.detalle.*` con cast `as Record<string, number>` (el tipo
+`CommodityExposure` declara `detalle` como `unknown`). Agregadas 3 filas
+nuevas al card: TON Contrato (CBOT ZC), TON Maíz reales, # Contratos.
+
+### Sidebar: rename "Commodities" → "Exposición" (abril 2026)
+
+El item del sidebar que apunta a `/risk-management` ahora se llama
+**Exposición** en lugar de **Commodities**. Refleja mejor el contenido
+del modulo (Benchmark, Rolling VaR, Exposicion, Matrices, Portafolio GR,
+Precios Locales*, Calculadora USDCOP). Cambio de label solamente; la
+ruta `/risk-management` y el archivo `SidebarNavList.tsx` solo cambian
+la prop `name`.
+
 ### Sidebar consolidado (abril 2026)
 
 ```
 Riesgos (solo super_admin y corp_admin)
   ├── Resumen            → /risk-resumen      (dashboard consolidado con selector de mes)
-  ├── Commodities        → /risk-management   (Benchmark, Rolling VaR, Exposicion, Matrices, Portafolio GR, Precios Locales*, Calculadora USDCOP)
+  ├── Exposición         → /risk-management   (Benchmark, Rolling VaR, Exposicion, Matrices, Portafolio GR, Precios Locales*, Calculadora USDCOP)
   ├── Creditos           → /loans
   ├── Portafolio OTC     → /portfolio
   ├── NDF Pricer         → /ndf-pricer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -646,6 +646,66 @@ UI actualizado en `risk-management/index.tsx` para leer desde
 `CommodityExposure` declara `detalle` como `unknown`). Agregadas 3 filas
 nuevas al card: TON Contrato (CBOT ZC), TON Maíz reales, # Contratos.
 
+### Formulaciones Super de Alimentos: AKOMEL, CEBES, ALMIDÓN (abril 2026)
+
+Tab **Exposición** en `/risk-management` ahora muestra 3 tarjetas adicionales
+condicionales en `company_id === SUPER_ALIMENTOS_ID` con el calculo de precio
+unitario por formulacion — port fiel del instructivo Python de Super.
+
+| Tarjeta | Materia prima | Unidad precio final | Productos derivados |
+|---------|---------------|---------------------|---------------------|
+| AKOMEL NH | Aceite de palma Malasia (FOB + flete + TRM) | COP/KG | Granel, Sin Lecitina Caja 15Kg, Saborizado Caja 15Kg |
+| CEBES MC 35 | Palmiste Malasia (CIF + flete + arancel + TRM) | COP/KG | CEBES MC 35 |
+| ALMIDÓN | Maiz CBOT ZC (¢/bu + base + flete) | USD/TON | Almidón |
+
+**Intermedios visibles en la UI (auditoria):**
+- AKOMEL: `paso1_*`, `paso2_*` por producto (Granel, SL, Sab)
+- CEBES: `materia_prima`, `precio_mp_planta`, `paso1_cebes`, `paso2_cebes`
+- ALMIDÓN: `precio_fob_usc_bu`, `precio_fob_usd_ton`, `credito_subproductos`,
+  `precio_neto_maiz`
+
+**TRM sincronizada con Xerenity:** Los campos TRM en AKOMEL y CEBES son
+**read-only** y leen de `params.trm` (alimentado por BanRep via `market_prices`).
+Se eliminaron los campos `akomel_trm` y `cebes_trm` independientes para evitar
+desincronizacion. ALMIDÓN no usa TRM porque el precio queda en USD/TON.
+
+**Exposicion Natural USD (input: KG anual por producto):**
+- AKOMEL/CEBES: `Exp. USD = KG × Precio (COP/KG) ÷ TRM`
+- ALMIDÓN:      `Exp. USD = KG × Precio (USD/TON) ÷ 1000`
+- AKOMEL tiene una fila **Total Exposición AKOMEL USD** que suma los 3
+  sub-productos (Granel + SL + Sab)
+
+**Conexion con tabla "Exposición por Commodity":**
+Las 3 formulaciones se agregan a la tabla de resumen como filas independientes
+(AKOMEL, CEBES_MC35, ALMIDON) via `buildSuperFormulaCommodities(params)`
+en `exposureCalculator.ts`. Esta funcion es exportada y la UI la llama en
+cada render (no en el fetch) para que el usuario vea los cambios de KG en
+vivo sin hacer click en "Actualizar". El `Total Commodities` y `Exposición
+Real USD` del Resumen tambien se recalculan en vivo desde los `displayRows`
+del render.
+
+**Flag `includeSuperFormulas`:** `fetchExposure(date, params, { includeSuperFormulas })`
+solo agrega las 3 filas al `ExposureResponse` cuando la empresa es Super.
+`handleFetchExposure` pasa `isSuper = selectedCompanyId === SUPER_ALIMENTOS_ID`.
+
+**Parametros nuevos en `ExposureParams`:** 30+ campos opcionales prefijados
+`akomel_*`, `cebes_*`, `almidon_*` + inputs `kg_akomel_granel_anual`,
+`kg_akomel_sl_anual`, `kg_akomel_sab_anual`, `kg_cebes_anual`, `kg_almidon_anual`.
+Defaults en `DEFAULT_EXPOSURE_PARAMS` (tomados del instructivo Python con
+valores actuales de la hoja de Super).
+
+**Validacion matematica:** 8/8 asserts del instructivo Python pasan
+(AKOMEL Granel/SL/Sab, CEBES, ALMIDÓN precios intermedios y finales).
+
+**Diseno UI:** las divisiones internas de cada tarjeta (AKOMEL NH Granel,
+Base Proceso, CEBES MC 35, etc.) se renderizan como encabezados de seccion
+con bold + fondo `#f1f5f9` + bordes para separar visualmente cada bloque
+de calculos.
+
+**Metodologia:** el tab "Metodología — Exposición" (boton al lado de
+Actualizar) incluye las formulas paso a paso de AKOMEL/CEBES/ALMIDÓN y
+explica la conexion en vivo entre las tarjetas y la tabla de resumen.
+
 ### Sidebar: rename "Commodities" → "Exposición" (abril 2026)
 
 El item del sidebar que apunta a `/risk-management` ahora se llama


### PR DESCRIPTION
closes #102

## Summary

Documenta las 3 tarjetas de formulacion agregadas al tab Exposicion en [avelezX/xerenity-fe#287](https://github.com/avelezX/xerenity-fe/pull/287).

- Calculadores puros (AKOMEL NH Granel/SL/Sab, CEBES MC 35, ALMIDON) con intermedios visibles
- TRM read-only sincronizada con Xerenity global (BanRep)
- Exposicion Natural USD = KG anual × Precio ÷ TRM (o ÷1000 para ALMIDON)
- Conexion en vivo tarjeta ↔ tabla via buildSuperFormulaCommodities
- 8/8 asserts matematicos validados contra Python

🤖 Generated with [Claude Code](https://claude.com/claude-code)