### PR TITLE
feat(risk): ACEITE_PALMA / FCPO collector + Super multi-tenant config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -520,6 +520,59 @@ KC requiere `MIDPOINT` y descarga en chunks de 60 dias. Duraciones mayores
 (e.g. 480d) causan timeout. El notebook `cafe.ipynb` incluye funcion
 `discover_contracts()` para la primera ejecucion (JSON vacio).
 
+### ACEITE_PALMA / FCPO collector (Bursa Malaysia, abril 2026)
+
+Collector de futuros de aceite de palma crudo (Crude Palm Oil, symbol FCPO)
+en Bursa Malaysia Derivatives. Agregado a `COMMODITY_CONFIG`, `JSON_PATHS`,
+`COLLECTORS` y a las 4 commodities de Super de Alimentos
+(`risk_company_config`) junto con MAIZ, AZUCAR y CACAO.
+
+| Config | Valor |
+|--------|-------|
+| Symbol | FCPO |
+| Exchange | BURSAMY (Bursa Malaysia Derivatives) |
+| Moneda | MYR (Ringgit Malayo) |
+| Meses | F, G, H, J, K, M, N, Q, U, V, X, Z (12 meses) |
+| Multiplier | 25 toneladas métricas por contrato |
+| Expiry | ~dia 15 del mes del contrato |
+| Notebook | `gestion_de_riesgos/collectors/ibkr/aceite_palma.ipynb` |
+| JSON | `data_fcpo.json` |
+| whatToShow | `MIDPOINT` (cae a TRADES/BID_ASK) |
+| useRTH | `False` (mercado asiático, sesión nocturna en UTC-5) |
+| Chunks | 250 días (cap para evitar timeouts en requests largas) |
+| Chart color | `#dc2626` (rojo) |
+
+**BLOQUEADOR ACTIVO (abril 2026) — no se pudo poblar data aun:**
+La cuenta de IBKR de Daniel no tiene subscripción a Bursa Malaysia Derivatives.
+Síntomas verificados corriendo el notebook con TWS abierto:
+- `reqMatchingSymbolsAsync('FCPO')` solo retorna el índice `FCPO.MY` en BURSAMY
+  (secType=IND, conId 689358788), NO los futuros mensuales
+- Intentar calificar cualquier futuro FCPO en cualquier exchange
+  (BURSAMY, MDEX, BMDX, BMDE, BMD, BURSA, KLSE, SGX) retorna
+  `Error 200: No se encuentra definición del activo solicitado` o
+  `El destino o la bolsa seleccionados no son válidos`
+- Pedir data histórica del índice retorna
+  `No data of type EODChart is available for the exchange 'BURSAMY'`
+
+**Para desbloquear** (pendiente decisión del usuario):
+- **Opción A:** subscribir a "Bursa Malaysia Derivatives (Top-of-Book)" en IBKR
+  Client Portal → Settings → Market Data Subscriptions (~USD 6-10/mes).
+  Cuando se active, re-correr `aceite_palma.ipynb` sin cambios de código.
+- **Opción B:** escribir un collector alternativo desde Yahoo Finance
+  (ticker `KPO=F`, front-month continuo) o MPOB — solo una serie diaria,
+  no la curva completa, pero suficiente para Rolling VaR y matrices.
+- **Opción C:** usar soybean oil (ZL, CBOT) como proxy correlacionado (~0.8).
+
+**Estado del codigo:**
+- `PalmOilCollector` clase, `COMMODITY_CONFIG['ACEITE_PALMA']`,
+  `JSON_PATHS['ACEITE_PALMA']` y `COLLECTORS['ACEITE_PALMA']` ya registrados.
+- `COMMODITY_TEMPLATES` en `xerenity-fe/src/lib/risk/companyConfig.ts`
+  incluye ACEITE_PALMA para que otras empresas lo puedan seleccionar en el setup.
+- Super de Alimentos ya tiene ACEITE_PALMA en sus commodities (PATCH a
+  `risk_company_config`), así que el asset aparece en Benchmark, Rolling VaR,
+  Matrices y Portafolio GR — simplemente muestra precios vacios hasta que
+  `risk_prices` tenga data.
+
 ### Collectors de precios
 
 Funciones en `gestion_de_riesgos/collectors/base_collector.py`:
@@ -529,6 +582,15 @@ Funciones en `gestion_de_riesgos/collectors/base_collector.py`:
 | `collect_all(start, end)` | Sube precios del front contract a `risk_prices` |
 | `collect_all_contracts(start?, end?)` | Sube precios de TODOS los contratos a `risk_prices_all_contracts` |
 | `IBUpdater.update_all()` | Actualiza JSONs locales desde TWS via ib_async |
+
+Registry `COLLECTORS` en `base_collector.py`:
+`MAIZ` (CornCollector), `AZUCAR` (SugarCollector), `CACAO` (CocoaCollector),
+`CAFE` (CoffeeCollector), `ACEITE_PALMA` (PalmOilCollector — bloqueado por
+subscripción IBKR), `USD` (TRMCollector).
+
+Cuando `update_all()` corre, procesa los commodities secuencialmente.
+El error de subscripción de FCPO no bloquea los demás — cada collector
+maneja sus propias excepciones y retorna `{'status': 'error', ...}` si falla.
 
 Para actualizar precios:
 1. Abrir TWS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -581,12 +581,86 @@ La pantalla de setup de commodities ahora permite guardar con **0 commodities**
 - Si el asset seleccionado ya no esta en la lista (cambio de empresa),
   se reemplaza automaticamente por el primero disponible
 
+### Resumen Exposicion Compañia — fix de campos (abril 2026)
+
+Bug en `fetchExposure` (`src/models/risk/riskApi.ts`): el resumen mostraba
+"Exposición Ventas Intl." igual al valor de "Exposición Real USD" aunque
+el input del usuario era distinto. Ejemplo concreto con Super de Alimentos:
+- Input Ventas Intl. (USD): `130,025,826`
+- Card mostraba: `82,693,807` (incorrecto, era el Real USD)
+
+**Causa:** el fetcher asignaba `exposicion_ventas_intl: result.exposicion_real_usd`
+en vez de `result.ventas_intl_usd`. Ademas `exposicion_pen` estaba hardcoded a 0.
+
+**Fix (mismo archivo, funcion `fetchExposure`):**
+```ts
+exposicion_ventas_intl: result.ventas_intl_usd,  // antes: result.exposicion_real_usd
+exposicion_pen:         result.ventas_pe_usd,    // antes: 0
+```
+
+**Formula segun la metodologia (tab Exposicion):**
+```
+Exposicion Real USD = Ventas Internacionales (USD) − Total Commodities (USD)
+```
+Para Super: `82,693,807 = 130,025,826 − 47,332,019` ✓
+
+### MAÍZ / GLUCOSA — calculo de # Contratos (abril 2026)
+
+Antes el card MAÍZ/GLUCOSA en el tab Exposicion no mostraba el numero de
+contratos de futuros CBOT ZC necesarios para cubrir la proyeccion de glucosa.
+Ademas las filas de "Precio Maíz (¢/ton)", "Precio Maíz (USD/ton)", "Crédito
+Subproductos", "Glucosa Materia", "Precio Glucosa" mostraban "—" porque el
+UI accedia a `mz.precio_usd_ton` pero el calculador los guarda en
+`mz.detalle.precio_usd_ton`.
+
+**Cambios en `src/lib/risk/exposureCalculator.ts`:**
+
+Constantes nuevas:
+```ts
+const TON_PER_BUSHEL = 0.0254;              // 1 bushel de maiz = 25.4 kg
+const CORN_BUSHELS_CONTRATO = 5000;         // CBOT Corn futures = 5,000 bu
+const CORN_TON_CONTRATO = 5000 × 0.0254;    // = 127 toneladas/contrato
+```
+
+Calculo correcto de # contratos en `calcularMaiz()`:
+```
+TON Maíz reales = TON Glucosa (proyeccion) × Factor Maíz→Glucosa
+                = 27,324 × 1.495
+                = 40,849 toneladas
+
+# Contratos   = TON Maíz reales ÷ TON Contrato CBOT ZC
+              = 40,849 ÷ 127
+              = 321.65 contratos
+```
+
+**Interpretacion:** si Super quisiera cobertura 100% de su exposicion al precio
+del maiz, tendria que comprar ~322 contratos ZC en CBOT. Es el equivalente al
+calculo que ya existia para AZUCAR (~783 contratos).
+
+`detalle` del `CommodityExposure` ahora incluye: `precio_cent_ton`,
+`precio_glucosa`, `ton_contrato` (127), `factor_maiz_glucosa`. Antes solo
+estaban `precio_usd_ton`, `credito_subproductos`, `glucosa_materia`, etc.
+
+UI actualizado en `risk-management/index.tsx` para leer desde
+`mz.detalle.*` con cast `as Record<string, number>` (el tipo
+`CommodityExposure` declara `detalle` como `unknown`). Agregadas 3 filas
+nuevas al card: TON Contrato (CBOT ZC), TON Maíz reales, # Contratos.
+
+### Sidebar: rename "Commodities" → "Exposición" (abril 2026)
+
+El item del sidebar que apunta a `/risk-management` ahora se llama
+**Exposición** en lugar de **Commodities**. Refleja mejor el contenido
+del modulo (Benchmark, Rolling VaR, Exposicion, Matrices, Portafolio GR,
+Precios Locales*, Calculadora USDCOP). Cambio de label solamente; la
+ruta `/risk-management` y el archivo `SidebarNavList.tsx` solo cambian
+la prop `name`.
+
 ### Sidebar consolidado (abril 2026)
 
 ```
 Riesgos (solo super_admin y corp_admin)
   ├── Resumen            → /risk-resumen      (dashboard consolidado con selector de mes)
-  ├── Commodities        → /risk-management   (Benchmark, Rolling VaR, Exposicion, Matrices, Portafolio GR, Precios Locales*, Calculadora USDCOP)
+  ├── Exposición         → /risk-management   (Benchmark, Rolling VaR, Exposicion, Matrices, Portafolio GR, Precios Locales*, Calculadora USDCOP)
   ├── Creditos           → /loans
   ├── Portafolio OTC     → /portfolio
   ├── NDF Pricer         → /ndf-pricer

--- a/gestion_de_riesgos/collectors/base_collector.py
+++ b/gestion_de_riesgos/collectors/base_collector.py
@@ -34,6 +34,7 @@ JSON_PATHS = {
     'AZUCAR': DATA_DIR / 'data_sb.json',
     'CACAO': DATA_DIR / 'data_cc.json',
     'CAFE': DATA_DIR / 'data_kc.json',
+    'ACEITE_PALMA': DATA_DIR / 'data_fcpo.json',
 }
 
 TRM_EXCEL_PATH = DATA_DIR / 'trm.xlsx'
@@ -90,6 +91,20 @@ COMMODITY_CONFIG = {
         'expiry_day': 19,          # ICE Coffee: ~19 del mes anterior al contrato
         'expiry_month_offset': -1,  # Vence en el mes anterior al mes del contrato
         'roll_days_before': 10,
+    },
+    'ACEITE_PALMA': {
+        'symbol': 'FCPO',
+        'exchanges': ['MDEX', 'BMDX'],   # Bursa Malaysia Derivatives
+        'months': {
+            'F': '01', 'G': '02', 'H': '03', 'J': '04',
+            'K': '05', 'M': '06', 'N': '07', 'Q': '08',
+            'U': '09', 'V': '10', 'X': '11', 'Z': '12',
+        },
+        'code_pattern': r'FCPO[FGHJKMNQUVXZ]\d{2}',
+        'expiry_day': 15,           # FCPO vence ~15 del mes del contrato
+        'expiry_month_offset': 0,
+        'roll_days_before': 10,
+        'currency': 'MYR',          # Precio en Ringgit Malayo
     },
 }
 
@@ -436,6 +451,18 @@ class CoffeeCollector(FuturesJSONCollector):
         )
 
 
+class PalmOilCollector(FuturesJSONCollector):
+    """Collector para futuros de Aceite de Palma (FCPO) - Bursa Malaysia via IB.
+    Precio en MYR/ton (25 toneladas métricas por contrato)."""
+
+    def __init__(self):
+        super().__init__(
+            'ACEITE_PALMA',
+            JSON_PATHS['ACEITE_PALMA'],
+            COMMODITY_CONFIG['ACEITE_PALMA'],
+        )
+
+
 class TRMCollector(BaseCollector):
     """
     Collector para TRM (USD/COP).
@@ -694,6 +721,7 @@ COLLECTORS = {
     'AZUCAR': SugarCollector,
     'CACAO': CocoaCollector,
     'CAFE': CoffeeCollector,
+    'ACEITE_PALMA': PalmOilCollector,
     'USD': TRMCollector,
 }
 

--- a/gestion_de_riesgos/collectors/ibkr/aceite_palma.ipynb
+++ b/gestion_de_riesgos/collectors/ibkr/aceite_palma.ipynb
@@ -1,0 +1,256 @@
+<cell id="cell-0"><cell_type>markdown</cell_type># Collector de Futuros de Aceite de Palma (FCPO) — Bursa Malaysia / MDEX
+
+Descarga toda la curva de futuros de Crude Palm Oil desde Interactive Brokers (TWS) y la guarda en `data_fcpo.json`.
+
+**Requisitos:**
+- TWS corriendo en `127.0.0.1:7496`
+- `pip install ib_async`
+
+**Contratos:** FCPO + meses F-Z (12 meses) + año 2 dígitos (e.g. FCPOK26, FCPOV26)
+**Exchange:** MDEX (Bursa Malaysia Derivatives)
+**Moneda:** MYR (Malaysian Ringgit)
+**Tamaño:** 25 toneladas métricas por contrato</cell id="cell-0">
+<cell id="cell-1"># ACEITE DE PALMA (FCPO) - ACTUALIZACIÓN DE PRECIOS DESDE INTERACTIVE BROKERS
+from ib_async import IB, Future
+from pathlib import Path
+from datetime import datetime, timedelta, date
+import pandas as pd
+import json, re, os, tempfile
+import asyncio
+
+# ========= CONFIG =========
+HOST = "127.0.0.1"
+PORT = 7496        # 7497 (paper) / 7496 (live)
+CLIENT_ID = 21     # Usar un ID distinto a los demas collectors
+
+JSON_PATH = Path(
+    r"C:\Users\DanielAristizabal\Saman\Banca de Inversión - Documents"
+    r"\Super de Alimentos\Gestión de riesgo\Data\data_fcpo.json"
+)
+
+# FECHA MÍNIMA - 180 días atrás (user requirement)
+START_DATE = (datetime.now() - timedelta(days=200)).strftime("%Y-%m-%d")
+# ==========================
+
+# FCPO (Bursa Malaysia) - contratos mensuales (12 meses)
+MONTH_LETTERS = {
+    'F': '01', 'G': '02', 'H': '03', 'J': '04',
+    'K': '05', 'M': '06', 'N': '07', 'Q': '08',
+    'U': '09', 'V': '10', 'X': '11', 'Z': '12',
+}
+MONTH_NUM_TO_LETTER = {v: k for k, v in MONTH_LETTERS.items()}
+ORDERED_MONTHS = ['F', 'G', 'H', 'J', 'K', 'M', 'N', 'Q', 'U', 'V', 'X', 'Z']
+
+# ---------- util contrato ----------
+def code_to_yyyymm(code: str) -> str:
+    m = re.fullmatch(r"FCPO([FGHJKMNQUVXZ])(\d{2})", code.strip().upper())
+    if not m:
+        raise ValueError(f"Código inválido FCPO: {code}")
+    letter, yy = m.groups()
+    yy_i = int(yy)
+    year = 2000 + yy_i if yy_i <= 79 else 1900 + yy_i
+    return f"{year}{MONTH_LETTERS[letter]}"
+
+def yyyymm_to_code(yyyymm: str) -> str:
+    y = int(yyyymm[:4])
+    mm = yyyymm[4:6]
+    return f"FCPO{MONTH_NUM_TO_LETTER[mm]}{str(y)[-2:]}"
+
+async def qualify_fcpo_async(ib: IB, yyyymm: str):
+    # Bursa Malaysia Derivatives en IBKR
+    for ex in ("MDEX", "BMDX"):
+        fut = Future(
+            symbol="FCPO",
+            lastTradeDateOrContractMonth=yyyymm,
+            exchange=ex,
+            currency="MYR",
+            includeExpired=True
+        )
+        try:
+            qs = await ib.qualifyContractsAsync(fut)
+            if qs:
+                return qs[0]
+        except Exception:
+            pass
+        await asyncio.sleep(0.05)
+    return None
+
+# ---------- históricos ----------
+async def fetch_history_from_date(ib: IB, q, start_date: str):
+    """Descarga histórico desde start_date hasta hoy."""
+    start_dt = pd.to_datetime(start_date)
+    end_dt = datetime.now()
+    days = max(1, (end_dt - start_dt).days + 1)
+    days = min(days, 250)  # cap para FCPO; mercados asiáticos pueden timeout en requests largas
+
+    for what in ("MIDPOINT", "TRADES", "BID_ASK"):
+        try:
+            bars = await ib.reqHistoricalDataAsync(
+                q, endDateTime="", durationStr=f"{days} D",
+                barSizeSetting="1 day", whatToShow=what,
+                useRTH=False, formatDate=2,  # Malasia: horario asiático, RTH no aplica bien
+                timeout=30
+            )
+            if bars:
+                rows = []
+                for b in bars:
+                    d = str(b.date)
+                    if d >= start_date:
+                        rows.append({
+                            "date": d, "open": b.open, "high": b.high, "low": b.low,
+                            "close": b.close, "volume": b.volume, "openinterest": None
+                        })
+                if rows:
+                    df = pd.DataFrame(rows).drop_duplicates("date").sort_values("date")
+                    return df.to_dict(orient="records")
+        except Exception:
+            pass
+        await asyncio.sleep(0.3)
+    return []
+
+# ---------- JSON I/O ----------
+def load_db(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+def atomic_save(path: Path, data: dict):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=path.name, dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.remove(tmp)
+        finally:
+            raise
+
+# ---------- descubrir contratos ----------
+async def discover_contracts(ib: IB, max_years_ahead: int = 2) -> list:
+    """Descubre contratos activos de FCPO buscando desde hoy hasta max_years_ahead años."""
+    today = date.today()
+    found = []
+    for year_offset in range(max_years_ahead + 1):
+        y = today.year + year_offset
+        for letter in ORDERED_MONTHS:
+            yyyymm = f"{y}{MONTH_LETTERS[letter]}"
+            code = f"FCPO{letter}{str(y)[-2:]}"
+            q = await qualify_fcpo_async(ib, yyyymm)
+            if q:
+                found.append(code)
+                print(f"  OK {code} ({yyyymm})")
+            await asyncio.sleep(0.1)
+    return found
+
+# ---------- main async ----------
+async def main_async():
+    db = load_db(JSON_PATH)
+
+    ib = IB()
+    try:
+        await ib.connectAsync(HOST, PORT, clientId=CLIENT_ID)
+    except Exception as e:
+        print("No se pudo conectar a IBKR:", e)
+        return
+
+    try:
+        today = datetime.now()
+
+        # Descubrir contratos si el JSON esta vacio
+        fcpo_contracts = [k for k in db.keys() if re.fullmatch(r"FCPO[FGHJKMNQUVXZ]\d{2}", k)]
+        if not fcpo_contracts:
+            print("JSON vacío — descubriendo contratos activos en IBKR (puede tomar varios minutos)...")
+            fcpo_contracts = await discover_contracts(ib)
+            for code in fcpo_contracts:
+                if code not in db:
+                    db[code] = []
+            print(f"\nDescubiertos: {len(fcpo_contracts)} contratos\n")
+        else:
+            print(f"Contratos en JSON: {len(fcpo_contracts)}")
+
+        print(f"Fecha mínima: {START_DATE}\n")
+
+        updated = 0
+
+        for code in sorted(fcpo_contracts):
+            try:
+                yyyymm = code_to_yyyymm(code)
+            except ValueError:
+                continue
+
+            q = await qualify_fcpo_async(ib, yyyymm)
+            if not q:
+                print(f"WARN {code}: no calificado en IBKR")
+                continue
+
+            bars = db.get(code, [])
+            bars = [r for r in bars if r["date"] >= START_DATE]
+            last_date = max((r["date"] for r in bars), default=None)
+
+            if last_date:
+                start = (pd.to_datetime(last_date) + timedelta(days=1)).strftime("%Y-%m-%d")
+                if start <= today.strftime("%Y-%m-%d"):
+                    new_rows = await fetch_history_from_date(ib, q, start)
+                    if new_rows:
+                        merged = (pd.concat([pd.DataFrame(bars), pd.DataFrame(new_rows)], ignore_index=True)
+                                  .drop_duplicates("date").sort_values("date"))
+                        db[code] = merged.to_dict(orient="records")
+                        print(f"OK {code}: +{len(new_rows)} filas (hasta {merged.iloc[-1]['date']})")
+                        updated += 1
+                    else:
+                        print(f"   {code}: al día ({last_date})")
+                else:
+                    print(f"   {code}: al día ({last_date})")
+            else:
+                rows = await fetch_history_from_date(ib, q, START_DATE)
+                if rows:
+                    db[code] = rows
+                    print(f"OK {code}: {len(rows)} filas (desde {START_DATE})")
+                    updated += 1
+                else:
+                    print(f"WARN {code}: sin datos")
+
+            await asyncio.sleep(0.5)
+
+        atomic_save(JSON_PATH, db)
+
+        print(f"\n{'='*50}")
+        print(f"Actualizados: {updated} | Archivo: {JSON_PATH.name}")
+        print(f"{'='*50}")
+
+        print("\nÚltima fecha por contrato:")
+        for code in sorted([k for k in db.keys() if re.fullmatch(r'FCPO[FGHJKMNQUVXZ]\d{2}', k)],
+                           key=lambda x: code_to_yyyymm(x)):
+            bars = db.get(code, [])
+            last = max((r["date"] for r in bars), default="N/A")
+            print(f"  {code}: {last}")
+
+    finally:
+        if ib.isConnected():
+            ib.disconnect()
+
+await main_async()</cell id="cell-1">
+<cell id="cell-2"># SUBIR A SUPABASE - Ejecutar después de actualizar el JSON
+import sys
+sys.path.insert(0, r'C:\Users\DanielAristizabal\Documents\GitHub\pysdk')
+
+from dotenv import load_dotenv
+load_dotenv(r'C:\Users\DanielAristizabal\Documents\GitHub\pysdk\.env')
+
+from gestion_de_riesgos.collectors.base_collector import collect_all, collect_all_contracts
+from datetime import date, timedelta
+
+# Ultimos 200 dias para cubrir la ventana de 180 dias del rolling VaR
+end = date.today().isoformat()
+start = (date.today() - timedelta(days=200)).isoformat()
+
+# 1) Front contract → risk_prices (para VaR y Benchmark)
+result1 = collect_all(start, end)
+print('collect_all:', result1)
+
+# 2) Todos los contratos → risk_prices_all_contracts (para Portafolio GR mark-to-market)
+result2 = collect_all_contracts(start, end)
+print('collect_all_contracts:', result2)</cell id="cell-2">


### PR DESCRIPTION
closes #103

## Summary

Agrega collector de futuros de aceite de palma crudo (FCPO, Bursa Malaysia Derivatives) siguiendo el patron de MAIZ/AZUCAR/CACAO/CAFE.

- Notebook `aceite_palma.ipynb` con `discover_contracts` + fetch 200d de historico
- `PalmOilCollector` + entry en `COMMODITY_CONFIG`, `JSON_PATHS`, `COLLECTORS`
- Super de Alimentos (PATCH a `risk_company_config`): ahora tiene 4 commodities
- `COMMODITY_TEMPLATES` en el frontend (xerenity-fe) incluye ACEITE_PALMA para que otras empresas lo puedan seleccionar

## Bloqueador conocido

Cuenta IBKR de Daniel no tiene subscripcion a Bursa Malaysia Derivatives — los futuros FCPO no califican (Error 200 "No se encuentra definicion del activo"). Documentado en CLAUDE.md con 3 opciones:

- **A)** Subscribir en IBKR (~$6-10/mes) — re-correr el notebook sin cambios
- **B)** Collector Yahoo Finance / MPOB — solo front-month, no la curva completa
- **C)** Soybean oil (ZL, CBOT) como proxy correlacionado (~0.8)

Decision diferida por el usuario; el codigo queda listo para cuando se resuelva.

## Archivos

- `gestion_de_riesgos/collectors/ibkr/aceite_palma.ipynb` (nuevo)
- `gestion_de_riesgos/collectors/base_collector.py` (+config +class +registry)
- `CLAUDE.md` (+seccion ACEITE_PALMA con bloqueador + opciones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)