### PR TITLE
fix(coffee): Py3.9 compat — from __future__ import annotations

### DIFF
--- a/src/collectors/anserma_coffee.py
+++ b/src/collectors/anserma_coffee.py
@@ -14,6 +14,8 @@ are not present as text in the HTML, so parsing is positional. If the number of
 price cells is not exactly 5, the parse aborts with an explicit error.
 """
 
+from __future__ import annotations
+
 import re
 import requests
 from datetime import date

--- a/src/collectors/fnc_coffee.py
+++ b/src/collectors/fnc_coffee.py
@@ -7,6 +7,8 @@ Source: https://federaciondecafeteros.org/wp/
   - Free, no API key required.
 """
 
+from __future__ import annotations
+
 import re
 import html
 import requests


### PR DESCRIPTION
closes #107

## Problem

Workflows `fnc_coffee_daily` y `anserma_coffee_daily` fallan en CI con:

```
File "src/collectors/fnc_coffee.py", line 30
    def _fetch_page() -> str | None:
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

Imagen Docker del runner (`avelezxerenity/xerenity:latest`) usa Python 3.9; PEP 604 (`X | Y`) requiere 3.10+.

## Fix

Un `from __future__ import annotations` por archivo (PEP 563). Postpone evaluation de annotations a strings, no las ejecuta en load time. Compatible con 3.7+.

## Verificacion

- `ast.parse()` pasa para ambos archivos
- Workflows se re-disparan despues del merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)