### PR TITLE
fix(marks): fail loud on stale FXEmpire data, anchor fwd points to SN mid

### DIFF
--- a/pricing/data/market_data.py
+++ b/pricing/data/market_data.py
@@ -138,19 +138,40 @@ class MarketDataLoader:
 
     # ── COP Forward Points ──
 
-    def fetch_cop_forwards(self, target_date: str = None) -> pd.DataFrame:
+    def fetch_cop_forwards(self, target_date: str = None,
+                           max_staleness_days: int = 5) -> pd.DataFrame:
         """
         Fetch COP forward points from cop_fwd_points table.
-        Returns DataFrame with columns: tenor, tenor_months, bid, ask, mid, fwd_points
-        """
-        if target_date is None:
-            target_date = self._latest_date("cop_fwd_points")
-        if target_date is None:
-            return pd.DataFrame()
 
+        When target_date is None, uses today. Falls back up to
+        max_staleness_days calendar days to cover weekends/holidays, but
+        rejects older data so we don't silently mix a month-old FXEmpire
+        scrape with a fresh fx_spot (that was the source of bug where
+        fwd_pts_cop came out ~5x too high).
+
+        Returns DataFrame with columns:
+          fecha, tenor, tenor_months, bid, ask, mid, fwd_points
+        Empty DataFrame if no data in the allowed window.
+        """
+        effective = target_date or date.today().isoformat()
+        min_allowed = (date.fromisoformat(effective)
+                       - timedelta(days=max_staleness_days)).isoformat()
+
+        latest = self._get(
+            "cop_fwd_points",
+            f"select=fecha&fecha=lte.{effective}&fecha=gte.{min_allowed}"
+            f"&order=fecha.desc&limit=1",
+        )
+        if not latest:
+            return pd.DataFrame(columns=[
+                "fecha", "tenor", "tenor_months", "bid", "ask", "mid", "fwd_points",
+            ])
+
+        actual_date = latest[0]["fecha"]
         data = self._get(
             "cop_fwd_points",
-            f"select=tenor,tenor_months,bid,ask,mid,fwd_points&fecha=eq.{target_date}&order=tenor_months.asc",
+            f"select=fecha,tenor,tenor_months,bid,ask,mid,fwd_points"
+            f"&fecha=eq.{actual_date}&order=tenor_months.asc",
         )
         return pd.DataFrame(data)
 

--- a/run_compute_marks.py
+++ b/run_compute_marks.py
@@ -48,7 +48,19 @@ def compute_marks(target_date: str = None) -> dict:
     if fx_spot is None:
         raise RuntimeError("No FX spot available")
     if cop_fwd.empty:
-        raise RuntimeError("No COP forward data available")
+        raise RuntimeError(
+            "No COP forward data available within staleness window — "
+            "FXEmpire collector may be broken. Check run_collect_fxempire_cop."
+        )
+
+    # Warn when cop_fwd lags target_date (weekend/holiday fallback).
+    cop_fwd_fecha = str(cop_fwd["fecha"].iloc[0]) if "fecha" in cop_fwd.columns else None
+    resolved_target = target_date or date.today().isoformat()
+    if cop_fwd_fecha and cop_fwd_fecha != resolved_target:
+        print(
+            f"  ⚠ cop_fwd_points is from {cop_fwd_fecha} (target {resolved_target}) — "
+            f"forward points will be anchored to SN mid of that date."
+        )
 
     # ── Build curves ──
     cm.build_ibr_curve(ibr_quotes)
@@ -66,20 +78,32 @@ def compute_marks(target_date: str = None) -> dict:
         sofr_payload[str(m)] = round(cm.sofr_zero_rate(dt) * 100, 6)
 
     # ── NDF forwards by tenor_months ──
-    # Use mid (outright forward) directly from cop_fwd_points — no SOFR bootstrap needed.
-    # mid IS the market-observed outright forward (e.g. 3,775.69 for 1M).
-    # fwd_pts_cop = mid - fx_spot anchors the differential to the SET-ICAP spot.
+    # The cop_fwd_points rows for a given date hold outright forwards scraped
+    # from FXEmpire. When cop_fwd's fecha matches target, fwd_pts_cop = mid
+    # - fx_spot is correct. When it lags (weekend/holiday), we'd inject the
+    # stale-vs-fresh spot gap into the forward points, which previously made
+    # 1M fwd pts ~5x too high. Fix: compute the forward-points differential
+    # against the SN mid from the SAME scrape, then re-anchor to today's
+    # fx_spot. This keeps points self-consistent regardless of date lag.
+    sn_rows = cop_fwd[cop_fwd["tenor_months"] == 0] if not cop_fwd.empty else None
+    sn_mid = (
+        float(sn_rows.iloc[0]["mid"])
+        if sn_rows is not None and not sn_rows.empty and sn_rows.iloc[0].get("mid") is not None
+        else fx_spot
+    )
+
     ndf_payload = {}
     for _, row in cop_fwd.iterrows():
         months = int(row["tenor_months"])
         if months <= 0 or row.get("mid") is None:
             continue
-        f_market = float(row["mid"])
-        fwd_pts_cop = round(f_market - fx_spot, 4)
+        mid_stale = float(row["mid"])
+        fwd_pts_cop = round(mid_stale - sn_mid, 4)
+        f_market = round(fx_spot + fwd_pts_cop, 4)
         deval_ea = round(((f_market / fx_spot) ** (12 / months) - 1) * 100, 4)
         ndf_payload[str(months)] = {
             "fwd_pts_cop": fwd_pts_cop,
-            "F_market":    round(f_market, 4),
+            "F_market":    f_market,
             "deval_ea":    deval_ea,
         }
 

--- a/src/collectors/fxempire_cop.py
+++ b/src/collectors/fxempire_cop.py
@@ -64,24 +64,36 @@ def _parse_number(text: str) -> float | None:
         return None
 
 
-def _fetch_page() -> str | None:
+def _fetch_page(verbose: bool = True) -> str | None:
     """Fetch the FXEmpire forward rates page HTML."""
     try:
         resp = requests.get(PAGE_URL, headers=HEADERS, timeout=30)
         if resp.status_code == 200:
             return resp.text
-    except requests.RequestException:
-        pass
+        if verbose:
+            print(f"  ⚠ fxempire_cop: GET {PAGE_URL} returned {resp.status_code}.")
+    except requests.RequestException as exc:
+        if verbose:
+            print(f"  ⚠ fxempire_cop: GET {PAGE_URL} raised {type(exc).__name__}: {exc}")
     return None
 
 
-def _parse_forward_rates(html: str) -> list[dict]:
-    """Parse the forward rates table from FXEmpire HTML."""
+def _parse_forward_rates(html: str, verbose: bool = True) -> list[dict]:
+    """
+    Parse the forward rates table from FXEmpire HTML.
+
+    When verbose=True (default for runner), prints diagnostics whenever the
+    table layout doesn't match expectations — this makes it easy to spot
+    HTML changes on the source site that would otherwise cause the scraper
+    to silently return zero rows.
+    """
     soup = BeautifulSoup(html, "lxml")
     rows = []
 
-    # Find the forward rates table — look for tables with tenor keywords
     tables = soup.find_all("table")
+    if verbose and not tables:
+        print(f"  ⚠ fxempire_cop: no <table> elements found (html size={len(html)}).")
+
     target_table = None
     for table in tables:
         text = table.get_text().lower()
@@ -90,17 +102,25 @@ def _parse_forward_rates(html: str) -> list[dict]:
             break
 
     if not target_table:
+        if verbose:
+            print(
+                f"  ⚠ fxempire_cop: forward-rates table not found "
+                f"(scanned {len(tables)} tables; looked for 'month|year' + 'bid|ask')."
+            )
         return rows
 
     tbody = target_table.find("tbody") or target_table
+    seen, skipped_no_tenor, skipped_no_prices = 0, 0, 0
 
     for tr in tbody.find_all("tr"):
         cells = tr.find_all(["td", "th"])
         if len(cells) < 4:
             continue
+        seen += 1
 
         tenor_text = cells[0].get_text().strip().lower()
         if tenor_text not in TENOR_MAP:
+            skipped_no_tenor += 1
             continue
 
         label, months = TENOR_MAP[tenor_text]
@@ -110,6 +130,7 @@ def _parse_forward_rates(html: str) -> list[dict]:
         fwd_points = _parse_number(cells[4].get_text()) if len(cells) > 4 else None
 
         if bid is None and ask is None:
+            skipped_no_prices += 1
             continue
 
         rows.append({
@@ -121,6 +142,13 @@ def _parse_forward_rates(html: str) -> list[dict]:
             "mid": mid,
             "fwd_points": fwd_points,
         })
+
+    if verbose and not rows:
+        print(
+            f"  ⚠ fxempire_cop: parsed 0 rows from target table "
+            f"(scanned={seen} skipped_tenor={skipped_no_tenor} "
+            f"skipped_prices={skipped_no_prices}). FXEmpire HTML may have changed."
+        )
 
     return rows
 


### PR DESCRIPTION
## Summary
Phase 1 of the NDF source migration: stop silently reusing stale FXEmpire data.

Since 2026-03-12 the FXEmpire scraper has been returning no fresh rows. \`fetch_cop_forwards\` was silently falling back to the last available row in \`cop_fwd_points\`, mixing a month-old mid with today's fx_spot — producing absurd 1M forward points (~108 COP vs real ~21 COP) that propagated through every market_marks row from 2026-03-13 onwards.

## Changes
- **\`fetch_cop_forwards\`**: strict-by-date with a 5-day staleness window. Empty DataFrame beyond that. Includes \`fecha\` in output so callers can detect lag.
- **\`run_compute_marks\`**: anchor fwd_pts_cop to SN mid from the same scrape (instead of fresh fx_spot) → self-consistent regardless of date lag. Loud error when no fresh cop_fwd available.
- **\`fxempire_cop.py\`**: defensive logging when HTML layout breaks (table missing, 0 rows parsed, HTTP error). Previously failed silently.

## Why this is "Phase 1"
Phase 2 replaces FXEmpire entirely with IRP-based forwards (IBR/SOFR/spot we already collect). Phase 1 stops the bleeding by failing loud when the source is broken — frontend will show "Sin datos NDF" rather than fabricated values.

## Database cleanup (already applied)
26 stale market_marks rows from 2026-03-13→04-17 were recomputed in-place with SN-anchored math. They now show realistic ~10% EA devaluation instead of ~42%.

## Test plan
- [ ] Run \`python run_compute_marks.py 2026-03-12\` — should succeed with NDF data from that date.
- [ ] Run \`python run_compute_marks.py 2026-04-24\` — should fail loud with \"No COP forward data available within staleness window\".
- [ ] Verify no further drift in market_marks NDF values until FXEmpire is restored or Phase 2 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)