### PR TITLE
feat(marks): derive NDF forwards from interest rate parity, drop FXEmpire

### DIFF
--- a/pricing/data/market_data.py
+++ b/pricing/data/market_data.py
@@ -138,19 +138,40 @@ class MarketDataLoader:
 
     # ── COP Forward Points ──
 
-    def fetch_cop_forwards(self, target_date: str = None) -> pd.DataFrame:
+    def fetch_cop_forwards(self, target_date: str = None,
+                           max_staleness_days: int = 5) -> pd.DataFrame:
         """
         Fetch COP forward points from cop_fwd_points table.
-        Returns DataFrame with columns: tenor, tenor_months, bid, ask, mid, fwd_points
-        """
-        if target_date is None:
-            target_date = self._latest_date("cop_fwd_points")
-        if target_date is None:
-            return pd.DataFrame()
 
+        When target_date is None, uses today. Falls back up to
+        max_staleness_days calendar days to cover weekends/holidays, but
+        rejects older data so we don't silently mix a month-old FXEmpire
+        scrape with a fresh fx_spot (that was the source of bug where
+        fwd_pts_cop came out ~5x too high).
+
+        Returns DataFrame with columns:
+          fecha, tenor, tenor_months, bid, ask, mid, fwd_points
+        Empty DataFrame if no data in the allowed window.
+        """
+        effective = target_date or date.today().isoformat()
+        min_allowed = (date.fromisoformat(effective)
+                       - timedelta(days=max_staleness_days)).isoformat()
+
+        latest = self._get(
+            "cop_fwd_points",
+            f"select=fecha&fecha=lte.{effective}&fecha=gte.{min_allowed}"
+            f"&order=fecha.desc&limit=1",
+        )
+        if not latest:
+            return pd.DataFrame(columns=[
+                "fecha", "tenor", "tenor_months", "bid", "ask", "mid", "fwd_points",
+            ])
+
+        actual_date = latest[0]["fecha"]
         data = self._get(
             "cop_fwd_points",
-            f"select=tenor,tenor_months,bid,ask,mid,fwd_points&fecha=eq.{target_date}&order=tenor_months.asc",
+            f"select=fecha,tenor,tenor_months,bid,ask,mid,fwd_points"
+            f"&fecha=eq.{actual_date}&order=tenor_months.asc",
         )
         return pd.DataFrame(data)
 

--- a/run_compute_marks.py
+++ b/run_compute_marks.py
@@ -34,11 +34,13 @@ def compute_marks(target_date: str = None) -> dict:
     cm = CurveManager()
 
     # ── Fetch ──
+    # NDF forwards no longer come from FXEmpire — they're derived from
+    # interest rate parity using the IBR + SOFR curves we already build.
+    # See "── NDF outright forwards ──" block below.
     ibr_quotes = loader.fetch_ibr_quotes(target_date=target_date)
     sofr_df    = loader.fetch_sofr_curve(target_date=target_date)
     # Use live SET-ICAP tick here — this is the job that WRITES the mark.
     fx_spot    = loader.fetch_usdcop_spot_live(target_date=target_date)
-    cop_fwd    = loader.fetch_cop_forwards(target_date=target_date)
     sofr_on    = loader.fetch_sofr_spot(target_date=target_date)
 
     if not ibr_quotes:
@@ -47,20 +49,6 @@ def compute_marks(target_date: str = None) -> dict:
         raise RuntimeError("No SOFR data available")
     if fx_spot is None:
         raise RuntimeError("No FX spot available")
-    if cop_fwd.empty:
-        raise RuntimeError(
-            "No COP forward data available within staleness window — "
-            "FXEmpire collector may be broken. Check run_collect_fxempire_cop."
-        )
-
-    # Warn when cop_fwd lags target_date (weekend/holiday fallback).
-    cop_fwd_fecha = str(cop_fwd["fecha"].iloc[0]) if "fecha" in cop_fwd.columns else None
-    resolved_target = target_date or date.today().isoformat()
-    if cop_fwd_fecha and cop_fwd_fecha != resolved_target:
-        print(
-            f"  ⚠ cop_fwd_points is from {cop_fwd_fecha} (target {resolved_target}) — "
-            f"forward points will be anchored to SN mid of that date."
-        )
 
     # ── Build curves ──
     cm.build_ibr_curve(ibr_quotes)
@@ -77,34 +65,32 @@ def compute_marks(target_date: str = None) -> dict:
         dt = cm.valuation_date + ql.Period(m, ql.Months)
         sofr_payload[str(m)] = round(cm.sofr_zero_rate(dt) * 100, 6)
 
-    # ── NDF forwards by tenor_months ──
-    # The cop_fwd_points rows for a given date hold outright forwards scraped
-    # from FXEmpire. When cop_fwd's fecha matches target, fwd_pts_cop = mid
-    # - fx_spot is correct. When it lags (weekend/holiday), we'd inject the
-    # stale-vs-fresh spot gap into the forward points, which previously made
-    # 1M fwd pts ~5x too high. Fix: compute the forward-points differential
-    # against the SN mid from the SAME scrape, then re-anchor to today's
-    # fx_spot. This keeps points self-consistent regardless of date lag.
-    sn_rows = cop_fwd[cop_fwd["tenor_months"] == 0] if not cop_fwd.empty else None
-    sn_mid = (
-        float(sn_rows.iloc[0]["mid"])
-        if sn_rows is not None and not sn_rows.empty and sn_rows.iloc[0].get("mid") is not None
-        else fx_spot
-    )
-
+    # ── NDF outright forwards from interest rate parity ──
+    # F(T) = S × DF_USD(T) / DF_COP(T) — standard textbook IRP.
+    #
+    # Replaces the old FXEmpire scrape entirely. The scraper had been
+    # broken since 2026-03-12 and was producing absurd forward points
+    # (~5x too high) because run_compute_marks kept reusing month-old
+    # mid values against a fresh spot.
+    #
+    # Trade-off: this gives us the *theoretical* forward, not the
+    # market-observed one. The difference (NDF basis) reflects
+    # convertibility risk + cross-currency basis. For a portfolio
+    # mark-to-model with monthly horizons that's fine; if the desk
+    # later needs market basis, add a manual override layer.
+    NDF_TENORS_MONTHS = [1, 2, 3, 6, 9, 12]
     ndf_payload = {}
-    for _, row in cop_fwd.iterrows():
-        months = int(row["tenor_months"])
-        if months <= 0 or row.get("mid") is None:
-            continue
-        mid_stale = float(row["mid"])
-        fwd_pts_cop = round(mid_stale - sn_mid, 4)
-        f_market = round(fx_spot + fwd_pts_cop, 4)
-        deval_ea = round(((f_market / fx_spot) ** (12 / months) - 1) * 100, 4)
+    for months in NDF_TENORS_MONTHS:
+        dt = cm.valuation_date + ql.Period(months, ql.Months)
+        df_sofr = cm.sofr_discount(dt)   # USD-leg DF
+        df_ibr  = cm.ibr_discount(dt)    # COP-leg DF
+        f_market = fx_spot * df_sofr / df_ibr
+        fwd_pts  = f_market - fx_spot
+        deval_ea = (f_market / fx_spot) ** (12 / months) - 1
         ndf_payload[str(months)] = {
-            "fwd_pts_cop": fwd_pts_cop,
-            "F_market":    f_market,
-            "deval_ea":    deval_ea,
+            "fwd_pts_cop": round(fwd_pts, 4),
+            "F_market":    round(f_market, 4),
+            "deval_ea":    round(deval_ea * 100, 4),
         }
 
     return {
@@ -117,7 +103,6 @@ def compute_marks(target_date: str = None) -> dict:
         "loader":      loader,
         "target_date": target_date,
         "sofr_df":     sofr_df,
-        "cop_fwd":     cop_fwd,
     }
 
 

--- a/run_compute_marks.py
+++ b/run_compute_marks.py
@@ -48,7 +48,19 @@ def compute_marks(target_date: str = None) -> dict:
     if fx_spot is None:
         raise RuntimeError("No FX spot available")
     if cop_fwd.empty:
-        raise RuntimeError("No COP forward data available")
+        raise RuntimeError(
+            "No COP forward data available within staleness window — "
+            "FXEmpire collector may be broken. Check run_collect_fxempire_cop."
+        )
+
+    # Warn when cop_fwd lags target_date (weekend/holiday fallback).
+    cop_fwd_fecha = str(cop_fwd["fecha"].iloc[0]) if "fecha" in cop_fwd.columns else None
+    resolved_target = target_date or date.today().isoformat()
+    if cop_fwd_fecha and cop_fwd_fecha != resolved_target:
+        print(
+            f"  ⚠ cop_fwd_points is from {cop_fwd_fecha} (target {resolved_target}) — "
+            f"forward points will be anchored to SN mid of that date."
+        )
 
     # ── Build curves ──
     cm.build_ibr_curve(ibr_quotes)
@@ -66,20 +78,32 @@ def compute_marks(target_date: str = None) -> dict:
         sofr_payload[str(m)] = round(cm.sofr_zero_rate(dt) * 100, 6)
 
     # ── NDF forwards by tenor_months ──
-    # Use mid (outright forward) directly from cop_fwd_points — no SOFR bootstrap needed.
-    # mid IS the market-observed outright forward (e.g. 3,775.69 for 1M).
-    # fwd_pts_cop = mid - fx_spot anchors the differential to the SET-ICAP spot.
+    # The cop_fwd_points rows for a given date hold outright forwards scraped
+    # from FXEmpire. When cop_fwd's fecha matches target, fwd_pts_cop = mid
+    # - fx_spot is correct. When it lags (weekend/holiday), we'd inject the
+    # stale-vs-fresh spot gap into the forward points, which previously made
+    # 1M fwd pts ~5x too high. Fix: compute the forward-points differential
+    # against the SN mid from the SAME scrape, then re-anchor to today's
+    # fx_spot. This keeps points self-consistent regardless of date lag.
+    sn_rows = cop_fwd[cop_fwd["tenor_months"] == 0] if not cop_fwd.empty else None
+    sn_mid = (
+        float(sn_rows.iloc[0]["mid"])
+        if sn_rows is not None and not sn_rows.empty and sn_rows.iloc[0].get("mid") is not None
+        else fx_spot
+    )
+
     ndf_payload = {}
     for _, row in cop_fwd.iterrows():
         months = int(row["tenor_months"])
         if months <= 0 or row.get("mid") is None:
             continue
-        f_market = float(row["mid"])
-        fwd_pts_cop = round(f_market - fx_spot, 4)
+        mid_stale = float(row["mid"])
+        fwd_pts_cop = round(mid_stale - sn_mid, 4)
+        f_market = round(fx_spot + fwd_pts_cop, 4)
         deval_ea = round(((f_market / fx_spot) ** (12 / months) - 1) * 100, 4)
         ndf_payload[str(months)] = {
             "fwd_pts_cop": fwd_pts_cop,
-            "F_market":    round(f_market, 4),
+            "F_market":    f_market,
             "deval_ea":    deval_ea,
         }
 

--- a/src/collectors/fxempire_cop.py
+++ b/src/collectors/fxempire_cop.py
@@ -64,24 +64,36 @@ def _parse_number(text: str) -> float | None:
         return None
 
 
-def _fetch_page() -> str | None:
+def _fetch_page(verbose: bool = True) -> str | None:
     """Fetch the FXEmpire forward rates page HTML."""
     try:
         resp = requests.get(PAGE_URL, headers=HEADERS, timeout=30)
         if resp.status_code == 200:
             return resp.text
-    except requests.RequestException:
-        pass
+        if verbose:
+            print(f"  ⚠ fxempire_cop: GET {PAGE_URL} returned {resp.status_code}.")
+    except requests.RequestException as exc:
+        if verbose:
+            print(f"  ⚠ fxempire_cop: GET {PAGE_URL} raised {type(exc).__name__}: {exc}")
     return None
 
 
-def _parse_forward_rates(html: str) -> list[dict]:
-    """Parse the forward rates table from FXEmpire HTML."""
+def _parse_forward_rates(html: str, verbose: bool = True) -> list[dict]:
+    """
+    Parse the forward rates table from FXEmpire HTML.
+
+    When verbose=True (default for runner), prints diagnostics whenever the
+    table layout doesn't match expectations — this makes it easy to spot
+    HTML changes on the source site that would otherwise cause the scraper
+    to silently return zero rows.
+    """
     soup = BeautifulSoup(html, "lxml")
     rows = []
 
-    # Find the forward rates table — look for tables with tenor keywords
     tables = soup.find_all("table")
+    if verbose and not tables:
+        print(f"  ⚠ fxempire_cop: no <table> elements found (html size={len(html)}).")
+
     target_table = None
     for table in tables:
         text = table.get_text().lower()
@@ -90,17 +102,25 @@ def _parse_forward_rates(html: str) -> list[dict]:
             break
 
     if not target_table:
+        if verbose:
+            print(
+                f"  ⚠ fxempire_cop: forward-rates table not found "
+                f"(scanned {len(tables)} tables; looked for 'month|year' + 'bid|ask')."
+            )
         return rows
 
     tbody = target_table.find("tbody") or target_table
+    seen, skipped_no_tenor, skipped_no_prices = 0, 0, 0
 
     for tr in tbody.find_all("tr"):
         cells = tr.find_all(["td", "th"])
         if len(cells) < 4:
             continue
+        seen += 1
 
         tenor_text = cells[0].get_text().strip().lower()
         if tenor_text not in TENOR_MAP:
+            skipped_no_tenor += 1
             continue
 
         label, months = TENOR_MAP[tenor_text]
@@ -110,6 +130,7 @@ def _parse_forward_rates(html: str) -> list[dict]:
         fwd_points = _parse_number(cells[4].get_text()) if len(cells) > 4 else None
 
         if bid is None and ask is None:
+            skipped_no_prices += 1
             continue
 
         rows.append({
@@ -121,6 +142,13 @@ def _parse_forward_rates(html: str) -> list[dict]:
             "mid": mid,
             "fwd_points": fwd_points,
         })
+
+    if verbose and not rows:
+        print(
+            f"  ⚠ fxempire_cop: parsed 0 rows from target table "
+            f"(scanned={seen} skipped_tenor={skipped_no_tenor} "
+            f"skipped_prices={skipped_no_prices}). FXEmpire HTML may have changed."
+        )
 
     return rows
 


### PR DESCRIPTION
## Summary
Phase 2 of NDF source migration — replaces FXEmpire scraping with theoretical forwards from interest rate parity using the IBR + SOFR curves already in the engine.

\`\`\`
F(T) = S × DF_USD(T) / DF_COP(T)
\`\`\`

Stacked on top of #109 (Phase 1 fail-loud). Either can merge first; if Phase 1 merges first, this PR's diff against main shrinks naturally.

## What changes
- \`run_compute_marks.py\`: NDF block computes forwards from \`cm.sofr_discount\` / \`cm.ibr_discount\` instead of reading \`cop_fwd_points\`. The fail-loud / SN-anchor / staleness checks are dropped because we no longer depend on FXEmpire at all.
- 32 historical market_marks rows (2026-03-13 → 2026-04-27) already backfilled via SQL using the same IRP formula. Future cron runs will produce QuantLib-precise values that overwrite them.

## Why
- FXEmpire scrape has been broken since 2026-03-12. Even when working, no SLA, no contract, fragile HTML.
- IRP-derived forwards are structurally consistent with the IBR/XCCY pricers (same curves).
- NDF nodes now move correctly when spot + rates move. Previously they froze at the last successful scrape.

## Trade-off
We lose the market-observed NDF basis (deviation from theoretical forward). For portfolio mark-to-model with monthly horizons this is fine. If the desk later needs live market basis (active NDF trading), add a manual override layer or subscribe to ICAP/Bloomberg.

## Test plan
- [ ] Run \`python run_compute_marks.py 2026-04-24\` — should succeed without touching cop_fwd_points; resulting NDF should match the SQL backfill ±$10 (compounding convention drift).
- [ ] Run \`python run_compute_marks.py 2026-03-12\` (a date with valid FXEmpire scrape) — IRP NDF should differ from FXEmpire-scrape NDF by the realized basis (~50-200 COP at 1Y).
- [ ] Spot-check Marks UI for 2026-04-24: 1M ≈ 3567, 12M ≈ 3847.

## Cleanup deferred
\`cop_fwd_points\` table and \`fxempire_cop\` collector remain in place — harmless reference, no longer on critical path. Retire in follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)